### PR TITLE
Global improvements to the codebase and minor bindings stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rust bindings for [Clay](https://github.com/nicbarker/clay), a UI layout library
     - (X) Scroll Container
     - (X) Custom Elements
 - ( ) Text Measuring
-- ( ) Element Ids
+- (X) Element Ids
 - ( ) Interactions
 - ( ) Debug Tools
 - ( ) Render Commands

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Rust bindings for [Clay](https://github.com/nicbarker/clay), a UI layout library
     - (X) Border Container
     - (X) Scroll Container
     - (X) Custom Elements
-- ( ) Text Measuring
+- (X) Text Measuring
 - (X) Element Ids
 - (O) Interactions
 - ( ) Debug Tools

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Rust bindings for [Clay](https://github.com/nicbarker/clay), a UI layout library
     - (X) Custom Elements
 - ( ) Text Measuring
 - (X) Element Ids
-- ( ) Interactions
+- (O) Interactions
 - ( ) Debug Tools
 - ( ) Render Commands
 - (O) Full Test Coverrage

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rust bindings for [Clay](https://github.com/nicbarker/clay), a UI layout library
     - (X) Floating Container
     - (X) Border Container
     - (X) Scroll Container
-    - ( ) Custom Elements
+    - (X) Custom Elements
 - ( ) Text Measuring
 - ( ) Element Ids
 - ( ) Interactions

--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -2,19 +2,27 @@ use crate::{
     bindings::*,
     color::Color,
     elements::{CornerRadius, ElementConfigType},
+    id::Id,
     mem::zeroed_init,
     TypedConfig,
 };
 
 pub struct BorderContainer {
     inner: Clay_BorderElementConfig,
+    id: Id,
 }
 
 impl BorderContainer {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     fn into_clay_border(width: u32, color: Color) -> Clay_Border {
@@ -65,7 +73,7 @@ impl BorderContainer {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::BorderContainer as _,
         }
     }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -1,6 +1,7 @@
 use crate::{
     bindings::*,
     elements::{ElementConfigType, PointerCaptureMode},
+    id::Id,
     math::{Dimensions, Vector2},
     mem::zeroed_init,
     TypedConfig,
@@ -22,13 +23,20 @@ pub enum FloatingAttachPointType {
 
 pub struct FloatingContainer {
     inner: Clay_FloatingElementConfig,
+    id: Id,
 }
 
 impl FloatingContainer {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     pub fn offset(&mut self, offset: Vector2) -> &mut Self {
@@ -73,7 +81,7 @@ impl FloatingContainer {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::FloatingContainer as _,
         }
     }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -1,6 +1,6 @@
 use crate::{
     bindings::*,
-    elements::{ElementConfigType, PointerCaptureMode},
+    elements::ElementConfigType,
     id::Id,
     math::{Dimensions, Vector2},
     mem::zeroed_init,
@@ -19,6 +19,13 @@ pub enum FloatingAttachPointType {
     RightTop = Clay_FloatingAttachPointType_CLAY_ATTACH_POINT_RIGHT_TOP,
     RightCenter = Clay_FloatingAttachPointType_CLAY_ATTACH_POINT_RIGHT_CENTER,
     RightBottom = Clay_FloatingAttachPointType_CLAY_ATTACH_POINT_RIGHT_BOTTOM,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum PointerCaptureMode {
+    Capture = Clay_PointerCaptureMode_CLAY_POINTER_CAPTURE_MODE_CAPTURE,
+    Passthrough = Clay_PointerCaptureMode_CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH,
 }
 
 pub struct FloatingContainer {

--- a/src/elements/containers/scroll.rs
+++ b/src/elements/containers/scroll.rs
@@ -1,14 +1,21 @@
-use crate::{bindings::*, elements::ElementConfigType, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, elements::ElementConfigType, id::Id, mem::zeroed_init, TypedConfig};
 
 pub struct ScrollContainer {
     inner: Clay_ScrollElementConfig,
+    id: Id,
 }
 
 impl ScrollContainer {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     pub fn horizontal(&mut self) -> &mut Self {
@@ -26,7 +33,7 @@ impl ScrollContainer {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::ScrollContainer as _,
         }
     }

--- a/src/elements/custom.rs
+++ b/src/elements/custom.rs
@@ -1,1 +1,34 @@
-use crate::bindings::*;
+use std::{ffi::c_void, marker::PhantomData};
+
+use crate::{bindings::*, mem::zeroed_init, TypedConfig};
+
+use super::ElementConfigType;
+
+pub struct Custom<Data> {
+    inner: Clay_CustomElementConfig,
+    phantom: PhantomData<Data>,
+}
+
+impl<Data> Custom<Data> {
+    pub fn new() -> Self {
+        Self {
+            inner: zeroed_init(),
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn data(&mut self, data: *const Data) -> &mut Self {
+        self.inner.customData = data as *mut c_void;
+        self
+    }
+
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreCustomElementConfig(self.inner) };
+
+        TypedConfig {
+            config_memory: memory as _,
+            id: zeroed_init(),
+            config_type: ElementConfigType::Image as _,
+        }
+    }
+}

--- a/src/elements/custom.rs
+++ b/src/elements/custom.rs
@@ -1,11 +1,12 @@
 use std::{ffi::c_void, marker::PhantomData};
 
-use crate::{bindings::*, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, id::Id, mem::zeroed_init, TypedConfig};
 
 use super::ElementConfigType;
 
 pub struct Custom<Data> {
     inner: Clay_CustomElementConfig,
+    id: Id,
     phantom: PhantomData<Data>,
 }
 
@@ -13,8 +14,14 @@ impl<Data> Custom<Data> {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
             phantom: PhantomData,
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     pub fn data(&mut self, data: *const Data) -> &mut Self {
@@ -27,7 +34,7 @@ impl<Data> Custom<Data> {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::Image as _,
         }
     }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,11 +1,12 @@
 use std::{ffi::c_void, marker::PhantomData};
 
-use crate::{bindings::*, math::Dimensions, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, id::Id, math::Dimensions, mem::zeroed_init, TypedConfig};
 
 use super::ElementConfigType;
 
 pub struct Image<Data> {
     inner: Clay_ImageElementConfig,
+    id: Id,
     phantom: PhantomData<Data>,
 }
 
@@ -13,8 +14,14 @@ impl<Data> Image<Data> {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
             phantom: PhantomData,
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     pub fn image_data(&mut self, data: *const Data) -> &mut Self {
@@ -32,7 +39,7 @@ impl<Data> Image<Data> {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::Image as _,
         }
     }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -21,13 +21,6 @@ pub enum ElementConfigType {
     Layout = 66,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[repr(u32)]
-pub enum PointerCaptureMode {
-    Capture = Clay_PointerCaptureMode_CLAY_POINTER_CAPTURE_MODE_CAPTURE,
-    Passthrough = Clay_PointerCaptureMode_CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH,
-}
-
 pub enum CornerRadius {
     All(f32),
     Individual {

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -56,10 +56,18 @@ impl From<CornerRadius> for Clay_CornerRadius {
 }
 impl From<Clay_CornerRadius> for CornerRadius {
     fn from(value: Clay_CornerRadius) -> Self {
-        if value.topLeft == value.topRight && value.topRight == value.bottomLeft && value.bottomLeft == value.bottomRight {
+        if value.topLeft == value.topRight
+            && value.topRight == value.bottomLeft
+            && value.bottomLeft == value.bottomRight
+        {
             Self::All(value.topLeft)
-        }else {
-            Self::Individual { top_left: value.topLeft, top_right: value.topRight, bottom_left: value.bottomLeft, bottom_right: value.bottomRight }
+        } else {
+            Self::Individual {
+                top_left: value.topLeft,
+                top_right: value.topRight,
+                bottom_left: value.bottomLeft,
+                bottom_right: value.bottomRight,
+            }
         }
     }
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -31,10 +31,10 @@ pub enum CornerRadius {
     },
 }
 
-impl Into<Clay_CornerRadius> for CornerRadius {
-    fn into(self) -> Clay_CornerRadius {
-        match self {
-            CornerRadius::All(radius) => Clay_CornerRadius {
+impl From<CornerRadius> for Clay_CornerRadius {
+    fn from(value: CornerRadius) -> Self {
+        match value {
+            CornerRadius::All(radius) => Self {
                 topLeft: radius,
                 topRight: radius,
                 bottomLeft: radius,
@@ -45,12 +45,21 @@ impl Into<Clay_CornerRadius> for CornerRadius {
                 top_right,
                 bottom_left,
                 bottom_right,
-            } => Clay_CornerRadius {
+            } => Self {
                 topLeft: top_left,
                 topRight: top_right,
                 bottomLeft: bottom_left,
                 bottomRight: bottom_right,
             },
+        }
+    }
+}
+impl From<Clay_CornerRadius> for CornerRadius {
+    fn from(value: Clay_CornerRadius) -> Self {
+        if value.topLeft == value.topRight && value.topRight == value.bottomLeft && value.bottomLeft == value.bottomRight {
+            Self::All(value.topLeft)
+        }else {
+            Self::Individual { top_left: value.topLeft, top_right: value.topRight, bottom_left: value.bottomLeft, bottom_right: value.bottomRight }
         }
     }
 }

--- a/src/elements/rectangle.rs
+++ b/src/elements/rectangle.rs
@@ -1,16 +1,23 @@
-use crate::{bindings::*, color::Color, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, color::Color, id::Id, mem::zeroed_init, TypedConfig};
 
 use super::{CornerRadius, ElementConfigType};
 
 pub struct Rectangle {
     inner: Clay_RectangleElementConfig,
+    id: Id,
 }
 
 impl Rectangle {
     pub fn new() -> Self {
         Self {
             inner: zeroed_init(),
+            id: Id::default(),
         }
+    }
+
+    pub fn attach(&mut self, id: Id) -> &mut Self {
+        self.id = id;
+        self
     }
 
     pub fn color(&mut self, color: Color) -> &mut Self {
@@ -28,7 +35,7 @@ impl Rectangle {
 
         TypedConfig {
             config_memory: memory as _,
-            id: zeroed_init(),
+            id: self.id.into(),
             config_type: ElementConfigType::Rectangle as _,
         }
     }

--- a/src/elements/text.rs
+++ b/src/elements/text.rs
@@ -12,9 +12,9 @@ pub struct TextElementConfig {
     inner: *mut Clay_TextElementConfig,
 }
 
-impl Into<*mut Clay_TextElementConfig> for TextElementConfig {
-    fn into(self) -> *mut Clay_TextElementConfig {
-        self.inner
+impl From<TextElementConfig> for *mut Clay_TextElementConfig {
+    fn from(value: TextElementConfig) -> Self {
+        value.inner
     }
 }
 

--- a/src/elements/text.rs
+++ b/src/elements/text.rs
@@ -17,6 +17,11 @@ impl From<TextElementConfig> for *mut Clay_TextElementConfig {
         value.inner
     }
 }
+impl From<*mut Clay_TextElementConfig> for TextElementConfig {
+    fn from(value: *mut Clay_TextElementConfig) -> Self {
+        Self { inner: value }
+    }
+}
 
 pub struct Text {
     inner: Clay_TextElementConfig,

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,34 @@
+use crate::{bindings::*, mem::zeroed_init};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Id {
+    inner: Clay_ElementId,
+}
+
+impl Id {
+    pub fn new(label: &str) -> Self {
+        Self {
+            inner: unsafe { Clay__HashString(label.into(), 0, 0) },
+        }
+    }
+
+    pub fn new_index(label: &str, index: u32) -> Self {
+        Self {
+            inner: unsafe { Clay__HashString(label.into(), index, 0) },
+        }
+    }
+}
+
+impl Default for Id {
+    fn default() -> Self {
+        Self {
+            inner: zeroed_init(),
+        }
+    }
+}
+
+impl Into<Clay_ElementId> for Id {
+    fn into(self) -> Clay_ElementId {
+        self.inner
+    }
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -27,8 +27,8 @@ impl Default for Id {
     }
 }
 
-impl Into<Clay_ElementId> for Id {
-    fn into(self) -> Clay_ElementId {
-        self.inner
+impl From<Id> for Clay_ElementId {
+    fn from(value: Id) -> Self {
+        value.inner
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -40,24 +40,24 @@ pub enum Sizing {
     Percent(f32),
 }
 
-impl Into<Clay_SizingAxis> for Sizing {
-    fn into(self) -> Clay_SizingAxis {
-        match self {
-            Sizing::Fit(min, max) => Clay_SizingAxis {
+impl From<Sizing> for Clay_SizingAxis {
+    fn from(value: Sizing) -> Self {
+        match value {
+            Sizing::Fit(min, max) => Self {
                 type_: SizingType::Fit as _,
                 __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
                     sizeMinMax: Clay_SizingMinMax { min, max },
                 },
             },
 
-            Sizing::Grow(min, max) => Clay_SizingAxis {
+            Sizing::Grow(min, max) => Self {
                 type_: SizingType::Grow as _,
                 __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
                     sizeMinMax: Clay_SizingMinMax { min, max },
                 },
             },
 
-            Sizing::Fixed(size) => Clay_SizingAxis {
+            Sizing::Fixed(size) => Self {
                 type_: SizingType::Fixed as _,
                 __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
                     sizeMinMax: Clay_SizingMinMax {
@@ -67,7 +67,7 @@ impl Into<Clay_SizingAxis> for Sizing {
                 },
             },
 
-            Sizing::Percent(percent) => Clay_SizingAxis {
+            Sizing::Percent(percent) => Self {
                 type_: SizingType::Percent as _,
                 __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
                     sizePercent: percent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod render_commands;
 mod mem;
 
 use elements::{text::TextElementConfig, ElementConfigType};
+use math::{Dimensions, Vector2};
 
 use crate::bindings::*;
 
@@ -27,17 +28,43 @@ pub struct Clay {
 }
 
 impl Clay {
-    pub fn new(width: f32, height: f32) -> Self {
+    pub fn new(dimensions: Dimensions) -> Self {
         let memory_size = unsafe { Clay_MinMemorySize() };
         let memory = vec![0; memory_size as usize];
         unsafe {
             let arena =
                 Clay_CreateArenaWithCapacityAndMemory(memory_size as _, memory.as_ptr() as _);
-            Clay_Initialize(arena, Clay_Dimensions { width, height });
+            Clay_Initialize(arena, dimensions.into());
         }
 
         Self { _memory: memory }
     }
+
+    pub fn layout_dimensions(&self, dimensions: Dimensions) {
+        unsafe {
+            Clay_SetLayoutDimensions(dimensions.into());
+        }
+    }
+    pub fn pointer_state(&self, position: Vector2, is_down: bool) {
+        unsafe {
+            Clay_SetPointerState(position.into(), is_down);
+        }
+    }
+    pub fn update_scroll_containers(
+        &self,
+        drag_scrolling_enabled: bool,
+        scroll_delta: Vector2,
+        delta_time: f32,
+    ) {
+        unsafe {
+            Clay_UpdateScrollContainers(drag_scrolling_enabled, scroll_delta.into(), delta_time);
+        }
+    }
+
+    // TODO: Uncomment once `clay.h` adds the declaration of `Clay_PointerOver`
+    // pub fn pointer_over(&self, id: Id) -> bool {
+    //     unsafe { Clay_PointerOver(id.into()) }
+    // }
 
     pub fn begin(&self) {
         unsafe { Clay_BeginLayout() };
@@ -106,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_begin() {
-        let clay = Clay::new(800.0, 600.0);
+        let clay = Clay::new(Dimensions::new(800.0, 600.0));
 
         clay.begin();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bindings;
 
 pub mod color;
 pub mod elements;
+pub mod id;
 pub mod layout;
 pub mod math;
 pub mod render_commands;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,22 @@ impl Clay {
     }
 }
 
-impl Into<Clay_String> for &str {
-    fn into(self) -> Clay_String {
-        Clay_String {
-            length: self.len() as _,
-            chars: self.as_ptr() as _,
+
+impl From<&str> for Clay_String {
+    fn from(value: &str) -> Self {
+        Self {
+            length: value.len() as _,
+            chars: value.as_ptr() as _,
+        }
+    }
+}
+impl From<Clay_String> for &str {
+    fn from(value: Clay_String) -> Self {
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                value.chars as *const u8,
+                value.length as _,
+            ))
         }
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,10 +1,16 @@
 use crate::bindings::*;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[repr(C)]
 pub struct Vector2 {
     x: f32,
     y: f32,
+}
+
+impl Vector2 {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
 }
 
 impl From<Clay_Vector2> for Vector2 {
@@ -18,11 +24,17 @@ impl From<Vector2> for Clay_Vector2 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[repr(C)]
 pub struct Dimensions {
     width: f32,
     height: f32,
+}
+
+impl Dimensions {
+    pub fn new(width: f32, height: f32) -> Self {
+        Self { width, height }
+    }
 }
 
 impl From<Clay_Dimensions> for Dimensions {

--- a/src/math.rs
+++ b/src/math.rs
@@ -47,3 +47,34 @@ impl From<Dimensions> for Clay_Dimensions {
         unsafe { std::mem::transmute(value) }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[repr(C)]
+pub struct BoundingBox {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+}
+
+impl BoundingBox {
+    pub fn new(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+impl From<Clay_BoundingBox> for BoundingBox {
+    fn from(value: Clay_BoundingBox) -> Self {
+        unsafe { std::mem::transmute(value) }
+    }
+}
+impl From<BoundingBox> for Clay_BoundingBox {
+    fn from(value: BoundingBox) -> Self {
+        unsafe { std::mem::transmute(value) }
+    }
+}


### PR DESCRIPTION
This PR has a lot of stuff:
- Adding `Custom` element
- Adding support of ids
- Moving some stuff around
- Adding some clay functions
- Converting all `Into`s into `From`s to avoid having both
- Text measuring stuff (set measuring function on clay object and shenanigans to make the `extern "C" fn` pointer work)