### PR TITLE
New API front and back to support RenderCommands

### DIFF
--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -46,12 +46,12 @@ impl From<Border> for Clay_Border {
 
 #[derive(Debug, Clone, Copy)]
 pub struct BorderContainer {
-    left: Border,
-    right: Border,
-    top: Border,
-    bottom: Border,
-    between_childs: Border,
-    corner_radius: CornerRadius,
+    pub left: Border,
+    pub right: Border,
+    pub top: Border,
+    pub bottom: Border,
+    pub between_childs: Border,
+    pub corner_radius: CornerRadius,
 }
 
 impl BorderContainer {

--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -3,53 +3,87 @@ use crate::{
     color::Color,
     elements::{CornerRadius, ElementConfigType},
     id::Id,
-    mem::zeroed_init,
     TypedConfig,
 };
 
+#[derive(Debug, Clone, Copy)]
+pub struct Border {
+    width: u32,
+    color: Color,
+}
+
+impl Border {
+    pub fn new(width: u32, color: Color) -> Self {
+        Self { width, color }
+    }
+}
+
+impl Default for Border {
+    fn default() -> Self {
+        Self {
+            width: 0,
+            color: Color::rgba(0., 0., 0., 0.),
+        }
+    }
+}
+
+impl From<Clay_Border> for Border {
+    fn from(value: Clay_Border) -> Self {
+        Self {
+            width: value.width,
+            color: value.color.into(),
+        }
+    }
+}
+impl From<Border> for Clay_Border {
+    fn from(value: Border) -> Self {
+        Self {
+            width: value.width,
+            color: value.color.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct BorderContainer {
-    inner: Clay_BorderElementConfig,
-    id: Id,
+    left: Border,
+    right: Border,
+    top: Border,
+    bottom: Border,
+    between_childs: Border,
+    corner_radius: CornerRadius,
 }
 
 impl BorderContainer {
     pub fn new() -> Self {
         Self {
-            inner: zeroed_init(),
-            id: Id::default(),
-        }
-    }
-
-    pub fn attach(&mut self, id: Id) -> &mut Self {
-        self.id = id;
-        self
-    }
-
-    fn into_clay_border(width: u32, color: Color) -> Clay_Border {
-        Clay_Border {
-            width,
-            color: color.into(),
+            left: Border::default(),
+            right: Border::default(),
+            top: Border::default(),
+            bottom: Border::default(),
+            between_childs: Border::default(),
+            corner_radius: CornerRadius::All(0.),
         }
     }
 
     pub fn left(&mut self, width: u32, color: Color) -> &mut Self {
-        self.inner.left = Self::into_clay_border(width, color);
+        self.left = Border::new(width, color);
         self
     }
     pub fn right(&mut self, width: u32, color: Color) -> &mut Self {
-        self.inner.right = Self::into_clay_border(width, color);
+        self.right = Border::new(width, color);
         self
     }
     pub fn top(&mut self, width: u32, color: Color) -> &mut Self {
-        self.inner.top = Self::into_clay_border(width, color);
+        self.top = Border::new(width, color);
         self
     }
     pub fn bottom(&mut self, width: u32, color: Color) -> &mut Self {
-        self.inner.bottom = Self::into_clay_border(width, color);
+        self.bottom = Border::new(width, color);
         self
     }
     pub fn between_childs(&mut self, width: u32, color: Color) -> &mut Self {
-        self.inner.betweenChildren = Self::into_clay_border(width, color);
+        self.between_childs = Border::new(width, color);
         self
     }
     pub fn all_directions(&mut self, width: u32, color: Color) -> &mut Self {
@@ -63,18 +97,43 @@ impl BorderContainer {
             .between_childs(width, color)
     }
 
-    pub fn corner_radius(&mut self, radius: CornerRadius) -> &mut Self {
-        self.inner.cornerRadius = radius.into();
+    pub fn corner_radius(&mut self, corner_radius: CornerRadius) -> &mut Self {
+        self.corner_radius = corner_radius;
         self
     }
 
-    pub fn end(&self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreBorderElementConfig(self.inner) };
+    pub fn end(&self, id: Id) -> TypedConfig {
+        let memory = unsafe { Clay__StoreBorderElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: self.id.into(),
+            id: id.into(),
             config_type: ElementConfigType::BorderContainer as _,
+        }
+    }
+}
+
+impl From<Clay_BorderElementConfig> for BorderContainer {
+    fn from(value: Clay_BorderElementConfig) -> Self {
+        Self {
+            left: value.left.into(),
+            right: value.right.into(),
+            top: value.top.into(),
+            bottom: value.bottom.into(),
+            between_childs: value.betweenChildren.into(),
+            corner_radius: value.cornerRadius.into(),
+        }
+    }
+}
+impl From<BorderContainer> for Clay_BorderElementConfig {
+    fn from(value: BorderContainer) -> Self {
+        Self {
+            left: value.left.into(),
+            right: value.right.into(),
+            top: value.top.into(),
+            bottom: value.bottom.into(),
+            betweenChildren: value.between_childs.into(),
+            cornerRadius: value.corner_radius.into(),
         }
     }
 }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -29,13 +29,13 @@ pub enum PointerCaptureMode {
 
 #[derive(Debug, Copy, Clone)]
 pub struct FloatingContainer {
-    offset: Vector2,
-    expand: Dimensions,
-    z_index: u16,
-    parent: u32,
-    parent_attachment: FloatingAttachPointType,
-    element_attachment: FloatingAttachPointType,
-    pointer_capture_mode: PointerCaptureMode,
+    pub offset: Vector2,
+    pub expand: Dimensions,
+    pub z_index: u16,
+    pub parent: u32,
+    pub parent_attachment: FloatingAttachPointType,
+    pub element_attachment: FloatingAttachPointType,
+    pub pointer_capture_mode: PointerCaptureMode,
 }
 
 impl FloatingContainer {

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -45,8 +45,8 @@ impl FloatingContainer {
             expand: Dimensions::default(),
             z_index: 0,
             parent: 0,
-            parent_attachment: FloatingAttachPointType::CenterCenter,
-            element_attachment: FloatingAttachPointType::CenterCenter,
+            parent_attachment: FloatingAttachPointType::LeftTop,
+            element_attachment: FloatingAttachPointType::LeftTop,
             pointer_capture_mode: PointerCaptureMode::Capture,
         }
     }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -104,9 +104,9 @@ impl From<Clay_FloatingElementConfig> for FloatingContainer {
             expand: value.expand.into(),
             z_index: value.zIndex,
             parent: value.parentId,
-            element_attachment: unsafe { std::mem::transmute(value.attachment.element) },
-            parent_attachment: unsafe { std::mem::transmute(value.attachment.parent) },
-            pointer_capture_mode: unsafe { std::mem::transmute(value.pointerCaptureMode) },
+            element_attachment: unsafe { core::mem::transmute(value.attachment.element) },
+            parent_attachment: unsafe { core::mem::transmute(value.attachment.parent) },
+            pointer_capture_mode: unsafe { core::mem::transmute(value.pointerCaptureMode) },
         }
     }
 }

--- a/src/elements/containers/scroll.rs
+++ b/src/elements/containers/scroll.rs
@@ -1,40 +1,53 @@
-use crate::{bindings::*, elements::ElementConfigType, id::Id, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, elements::ElementConfigType, id::Id, TypedConfig};
 
+#[derive(Debug, Copy, Clone)]
 pub struct ScrollContainer {
-    inner: Clay_ScrollElementConfig,
-    id: Id,
+    pub horizontal: bool,
+    pub vertical: bool,
 }
 
 impl ScrollContainer {
     pub fn new() -> Self {
         Self {
-            inner: zeroed_init(),
-            id: Id::default(),
+            horizontal: false,
+            vertical: false,
         }
     }
 
-    pub fn attach(&mut self, id: Id) -> &mut Self {
-        self.id = id;
-        self
-    }
-
     pub fn horizontal(&mut self) -> &mut Self {
-        self.inner.horizontal = true;
+        self.horizontal = true;
         self
     }
 
     pub fn vertical(&mut self) -> &mut Self {
-        self.inner.vertical = true;
+        self.vertical = true;
         self
     }
 
-    pub fn end(&self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreScrollElementConfig(self.inner) };
+    pub fn end(&self, id: Id) -> TypedConfig {
+        let memory = unsafe { Clay__StoreScrollElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: self.id.into(),
+            id: id.into(),
             config_type: ElementConfigType::ScrollContainer as _,
+        }
+    }
+}
+
+impl From<Clay_ScrollElementConfig> for ScrollContainer {
+    fn from(value: Clay_ScrollElementConfig) -> Self {
+        Self {
+            horizontal: value.horizontal,
+            vertical: value.vertical,
+        }
+    }
+}
+impl From<ScrollContainer> for Clay_ScrollElementConfig {
+    fn from(value: ScrollContainer) -> Self {
+        Self {
+            horizontal: value.horizontal,
+            vertical: value.vertical,
         }
     }
 }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,46 +1,57 @@
-use core::{ffi::c_void, marker::PhantomData};
+use core::ffi::c_void;
 
-use crate::{bindings::*, id::Id, math::Dimensions, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, id::Id, math::Dimensions, TypedConfig};
 
 use super::ElementConfigType;
 
-pub struct Image<Data> {
-    inner: Clay_ImageElementConfig,
-    id: Id,
-    phantom: PhantomData<Data>,
+#[derive(Debug, Copy, Clone)]
+pub struct Image {
+    pub data: *mut c_void,
+    pub source_dimensions: Dimensions,
 }
 
-impl<Data> Image<Data> {
+impl Image {
     pub fn new() -> Self {
         Self {
-            inner: zeroed_init(),
-            id: Id::default(),
-            phantom: PhantomData,
+            data: std::ptr::null_mut(),
+            source_dimensions: Dimensions::default(),
         }
     }
 
-    pub fn attach(&mut self, id: Id) -> &mut Self {
-        self.id = id;
-        self
-    }
-
-    pub fn image_data(&mut self, data: *const Data) -> &mut Self {
-        self.inner.imageData = data as *mut c_void;
+    pub fn data<Data>(&mut self, data: &mut Data) -> &mut Self {
+        self.data = data as *mut _ as *mut c_void;
         self
     }
 
     pub fn source_dimensions(&mut self, dimensions: Dimensions) -> &mut Self {
-        self.inner.sourceDimensions = dimensions.into();
+        self.source_dimensions = dimensions;
         self
     }
 
-    pub fn end(&self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreImageElementConfig(self.inner) };
+    pub fn end(&self, id: Id) -> TypedConfig {
+        let memory = unsafe { Clay__StoreImageElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: self.id.into(),
+            id: id.into(),
             config_type: ElementConfigType::Image as _,
+        }
+    }
+}
+
+impl From<Clay_ImageElementConfig> for Image {
+    fn from(value: Clay_ImageElementConfig) -> Self {
+        Self {
+            data: value.imageData,
+            source_dimensions: value.sourceDimensions.into(),
+        }
+    }
+}
+impl From<Image> for Clay_ImageElementConfig {
+    fn from(value: Image) -> Self {
+        Self {
+            imageData: value.data,
+            sourceDimensions: value.source_dimensions.into(),
         }
     }
 }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -13,7 +13,7 @@ pub struct Image {
 impl Image {
     pub fn new() -> Self {
         Self {
-            data: std::ptr::null_mut(),
+            data: core::ptr::null_mut(),
             source_dimensions: Dimensions::default(),
         }
     }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -21,6 +21,7 @@ pub enum ElementConfigType {
     Layout = 66,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CornerRadius {
     All(f32),
     Individual {

--- a/src/elements/rectangle.rs
+++ b/src/elements/rectangle.rs
@@ -1,42 +1,55 @@
-use crate::{bindings::*, color::Color, id::Id, mem::zeroed_init, TypedConfig};
+use crate::{bindings::*, color::Color, id::Id, TypedConfig};
 
 use super::{CornerRadius, ElementConfigType};
 
+#[derive(Debug, Copy, Clone)]
 pub struct Rectangle {
-    inner: Clay_RectangleElementConfig,
-    id: Id,
+    pub color: Color,
+    pub corner_radius: CornerRadius,
 }
 
 impl Rectangle {
     pub fn new() -> Self {
         Self {
-            inner: zeroed_init(),
-            id: Id::default(),
+            color: Color::rgba(0., 0., 0., 0.),
+            corner_radius: CornerRadius::All(0.),
         }
     }
 
-    pub fn attach(&mut self, id: Id) -> &mut Self {
-        self.id = id;
-        self
-    }
-
     pub fn color(&mut self, color: Color) -> &mut Self {
-        self.inner.color = color.into();
+        self.color = color;
         self
     }
 
-    pub fn corner_radius(&mut self, radius: CornerRadius) -> &mut Self {
-        self.inner.cornerRadius = radius.into();
+    pub fn corner_radius(&mut self, corner_radius: CornerRadius) -> &mut Self {
+        self.corner_radius = corner_radius;
         self
     }
 
-    pub fn end(&self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreRectangleElementConfig(self.inner) };
+    pub fn end(&self, id: Id) -> TypedConfig {
+        let memory = unsafe { Clay__StoreRectangleElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: self.id.into(),
+            id: id.into(),
             config_type: ElementConfigType::Rectangle as _,
+        }
+    }
+}
+
+impl From<Clay_RectangleElementConfig> for Rectangle {
+    fn from(value: Clay_RectangleElementConfig) -> Self {
+        Self {
+            color: value.color.into(),
+            corner_radius: value.cornerRadius.into(),
+        }
+    }
+}
+impl From<Rectangle> for Clay_RectangleElementConfig {
+    fn from(value: Rectangle) -> Self {
+        Self {
+            color: value.color.into(),
+            cornerRadius: value.corner_radius.into(),
         }
     }
 }

--- a/src/elements/text.rs
+++ b/src/elements/text.rs
@@ -25,12 +25,12 @@ impl From<*mut Clay_TextElementConfig> for TextElementConfig {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Text {
-    color: Color,
-    font_id: u16,
-    font_size: u16,
-    letter_spacing: u16,
-    line_height: u16,
-    wrap_mode: TextElementConfigWrapMode,
+    pub color: Color,
+    pub font_id: u16,
+    pub font_size: u16,
+    pub letter_spacing: u16,
+    pub line_height: u16,
+    pub wrap_mode: TextElementConfigWrapMode,
 }
 
 impl Text {

--- a/src/elements/text.rs
+++ b/src/elements/text.rs
@@ -90,7 +90,7 @@ impl From<Clay_TextElementConfig> for Text {
             font_size: value.fontSize,
             letter_spacing: value.letterSpacing,
             line_height: value.lineHeight,
-            wrap_mode: unsafe { std::mem::transmute(value.wrapMode) },
+            wrap_mode: unsafe { core::mem::transmute(value.wrapMode) },
         }
     }
 }

--- a/src/layout/alignment.rs
+++ b/src/layout/alignment.rs
@@ -1,0 +1,46 @@
+use crate::bindings::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LayoutAlignmentX {
+    Left = Clay_LayoutAlignmentX_CLAY_ALIGN_X_LEFT,
+    Center = Clay_LayoutAlignmentX_CLAY_ALIGN_X_CENTER,
+    Right = Clay_LayoutAlignmentX_CLAY_ALIGN_X_RIGHT,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LayoutAlignmentY {
+    Top = Clay_LayoutAlignmentY_CLAY_ALIGN_Y_TOP,
+    Center = Clay_LayoutAlignmentY_CLAY_ALIGN_Y_CENTER,
+    Bottom = Clay_LayoutAlignmentY_CLAY_ALIGN_Y_BOTTOM,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Alignment {
+    pub x: LayoutAlignmentX,
+    pub y: LayoutAlignmentY,
+}
+
+impl Alignment {
+    pub fn new(x: LayoutAlignmentX, y: LayoutAlignmentY) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<Clay_ChildAlignment> for Alignment {
+    fn from(value: Clay_ChildAlignment) -> Self {
+        Self {
+            x: unsafe { core::mem::transmute(value.x) },
+            y: unsafe { core::mem::transmute(value.y) },
+        }
+    }
+}
+impl From<Alignment> for Clay_ChildAlignment {
+    fn from(value: Alignment) -> Self {
+        Self {
+            x: value.x as _,
+            y: value.y as _,
+        }
+    }
+}

--- a/src/layout/padding.rs
+++ b/src/layout/padding.rs
@@ -1,0 +1,30 @@
+use crate::bindings::*;
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct Padding {
+    pub x: u16,
+    pub y: u16,
+}
+
+impl Padding {
+    pub fn new(x: u16, y: u16) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<Clay_Padding> for Padding {
+    fn from(value: Clay_Padding) -> Self {
+        Self {
+            x: value.x,
+            y: value.y,
+        }
+    }
+}
+impl From<Padding> for Clay_Padding {
+    fn from(value: Padding) -> Self {
+        Self {
+            x: value.x,
+            y: value.y,
+        }
+    }
+}

--- a/src/layout/sizing.rs
+++ b/src/layout/sizing.rs
@@ -1,0 +1,75 @@
+use crate::bindings::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SizingType {
+    Fit = Clay__SizingType_CLAY__SIZING_TYPE_FIT,
+    Grow = Clay__SizingType_CLAY__SIZING_TYPE_GROW,
+    Percent = Clay__SizingType_CLAY__SIZING_TYPE_PERCENT,
+    Fixed = Clay__SizingType_CLAY__SIZING_TYPE_FIXED,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Sizing {
+    Fit(f32, f32),
+    Grow(f32, f32),
+    Fixed(f32),
+    Percent(f32),
+}
+
+impl From<Clay_SizingAxis> for Sizing {
+    fn from(value: Clay_SizingAxis) -> Self {
+        match unsafe { core::mem::transmute(value.type_) } {
+            SizingType::Fit => {
+                let min_max = unsafe { value.__bindgen_anon_1.sizeMinMax };
+                Self::Fit(min_max.min, min_max.max)
+            }
+            SizingType::Grow => {
+                let min_max = unsafe { value.__bindgen_anon_1.sizeMinMax };
+                Self::Grow(min_max.min, min_max.max)
+            }
+            SizingType::Fixed => {
+                let min_max = unsafe { value.__bindgen_anon_1.sizeMinMax };
+                Self::Fixed(min_max.min)
+            }
+            SizingType::Percent => {
+                let percent = unsafe { value.__bindgen_anon_1.sizePercent };
+                Self::Percent(percent)
+            }
+        }
+    }
+}
+
+impl From<Sizing> for Clay_SizingAxis {
+    fn from(value: Sizing) -> Self {
+        match value {
+            Sizing::Fit(min, max) => Self {
+                type_: SizingType::Fit as _,
+                __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
+                    sizeMinMax: Clay_SizingMinMax { min, max },
+                },
+            },
+            Sizing::Grow(min, max) => Self {
+                type_: SizingType::Grow as _,
+                __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
+                    sizeMinMax: Clay_SizingMinMax { min, max },
+                },
+            },
+            Sizing::Fixed(size) => Self {
+                type_: SizingType::Fixed as _,
+                __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
+                    sizeMinMax: Clay_SizingMinMax {
+                        min: size,
+                        max: size,
+                    },
+                },
+            },
+            Sizing::Percent(percent) => Self {
+                type_: SizingType::Percent as _,
+                __bindgen_anon_1: Clay_SizingAxis__bindgen_ty_1 {
+                    sizePercent: percent,
+                },
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl Clay {
 
     pub fn end(&self) -> impl Iterator<Item = RenderCommand> {
         let array = unsafe { Clay_EndLayout() };
-        let slice = unsafe { std::slice::from_raw_parts(array.internalArray, array.length as _) };
+        let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };
         slice
             .into_iter()
             .map(|command| RenderCommand::from(*command))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,11 @@ mod tests {
     use std::mem;
 
     use color::Color;
-    use elements::text::Text;
+    use elements::{
+        containers::border::BorderContainer, rectangle::Rectangle, text::Text, CornerRadius,
+    };
     use id::Id;
+    use layout::{padding::Padding, sizing::Sizing, Layout};
 
     use super::*;
 
@@ -202,24 +205,24 @@ mod tests {
 
         clay.with(
             [
-                layout::Layout::new()
-                    .sizing_width(layout::Sizing::Fixed(100.0))
-                    .sizing_height(layout::Sizing::Fixed(100.0))
-                    .padding((10, 10))
+                Layout::new()
+                    .width(Sizing::Fixed(100.0))
+                    .height(Sizing::Fixed(100.0))
+                    .padding(Padding::new(10, 10))
                     .end(),
-                elements::rectangle::Rectangle::new()
+                Rectangle::new()
                     .color(Color::rgb(255., 255., 255.))
                     .end(Id::new("parent_rect")),
             ],
             |clay| {
                 clay.with(
                     [
-                        layout::Layout::new()
-                            .sizing_width(layout::Sizing::Fixed(100.0))
-                            .sizing_height(layout::Sizing::Fixed(100.0))
-                            .padding((10, 10))
+                        Layout::new()
+                            .width(Sizing::Fixed(100.0))
+                            .height(Sizing::Fixed(100.0))
+                            .padding(Padding::new(10, 10))
                             .end(),
-                        elements::rectangle::Rectangle::new()
+                        Rectangle::new()
                             .color(Color::rgb(255., 255., 255.))
                             .end(Id::new("rect_under_rect")),
                     ],
@@ -231,20 +234,20 @@ mod tests {
         );
         clay.with(
             [
-                layout::Layout::new().padding((16, 16)).end(),
-                elements::containers::border::BorderContainer::new()
+                Layout::new().padding(Padding::new(16, 16)).end(),
+                BorderContainer::new()
                     .all_directions(2, Color::rgb(255., 255., 0.))
-                    .corner_radius(elements::CornerRadius::All(25.))
+                    .corner_radius(CornerRadius::All(25.))
                     .end(Id::new_index("Border_container", 1)),
             ],
             |clay| {
                 clay.with(
                     [
-                        layout::Layout::new()
-                            .sizing_width(layout::Sizing::Fixed(50.0))
-                            .sizing_height(layout::Sizing::Fixed(50.0))
+                        Layout::new()
+                            .width(Sizing::Fixed(50.0))
+                            .height(Sizing::Fixed(50.0))
                             .end(),
-                        elements::rectangle::Rectangle::new()
+                        Rectangle::new()
                             .color(Color::rgb(0., 255., 255.))
                             .end(Id::new("rect_under_border")),
                     ],

--- a/src/render_commands.rs
+++ b/src/render_commands.rs
@@ -1,4 +1,11 @@
-use crate::bindings::*;
+use crate::{
+    bindings::*,
+    elements::{
+        containers::border::BorderContainer, custom::Custom, image::Image, rectangle::Rectangle,
+        text::Text,
+    },
+    math::BoundingBox,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(u32)]
@@ -11,4 +18,59 @@ pub enum RenderCommandType {
     ScissorStart = Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_SCISSOR_START,
     ScissorEnd = Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_SCISSOR_END,
     Custom = Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_CUSTOM,
+}
+
+#[derive(Debug, Clone)]
+pub enum RenderCommandConfig {
+    None(),
+    Rectangle(Rectangle),
+    Border(BorderContainer),
+    Text(String, Text),
+    Image(Image),
+    ScissorStart(),
+    ScissorEnd(),
+    Custom(Custom),
+}
+
+impl From<&Clay_RenderCommand> for RenderCommandConfig {
+    fn from(value: &Clay_RenderCommand) -> Self {
+        match unsafe { std::mem::transmute(value.commandType) } {
+            RenderCommandType::None => Self::None(),
+            RenderCommandType::Rectangle => Self::Rectangle(Rectangle::from(unsafe {
+                (&mut *(value.config.rectangleElementConfig)).to_owned()
+            })),
+            RenderCommandType::Border => Self::Border(BorderContainer::from(unsafe {
+                (&mut *(value.config.borderElementConfig)).to_owned()
+            })),
+            RenderCommandType::Text => Self::Text(
+                <Clay_String as Into<&str>>::into(value.text).to_string(),
+                Text::from(unsafe { (&mut *(value.config.textElementConfig)).to_owned() }),
+            ),
+            RenderCommandType::Image => Self::Image(Image::from(unsafe {
+                (&mut *(value.config.imageElementConfig)).to_owned()
+            })),
+            RenderCommandType::ScissorStart => Self::ScissorStart(),
+            RenderCommandType::ScissorEnd => Self::ScissorEnd(),
+            RenderCommandType::Custom => Self::Custom(Custom::from(unsafe {
+                (&mut *(value.config.customElementConfig)).to_owned()
+            })),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderCommand {
+    pub id: u32,
+    pub bounding_box: BoundingBox,
+    pub config: RenderCommandConfig,
+}
+
+impl From<Clay_RenderCommand> for RenderCommand {
+    fn from(value: Clay_RenderCommand) -> Self {
+        Self {
+            id: value.id,
+            bounding_box: value.boundingBox.into(),
+            config: (&value).into(),
+        }
+    }
 }

--- a/src/render_commands.rs
+++ b/src/render_commands.rs
@@ -34,25 +34,25 @@ pub enum RenderCommandConfig {
 
 impl From<&Clay_RenderCommand> for RenderCommandConfig {
     fn from(value: &Clay_RenderCommand) -> Self {
-        match unsafe { std::mem::transmute(value.commandType) } {
+        match unsafe { core::mem::transmute(value.commandType) } {
             RenderCommandType::None => Self::None(),
-            RenderCommandType::Rectangle => Self::Rectangle(Rectangle::from(unsafe {
-                (&mut *(value.config.rectangleElementConfig)).to_owned()
+            RenderCommandType::Rectangle => Self::Rectangle(Rectangle::from(*unsafe {
+                &mut *(value.config.rectangleElementConfig)
             })),
-            RenderCommandType::Border => Self::Border(BorderContainer::from(unsafe {
-                (&mut *(value.config.borderElementConfig)).to_owned()
+            RenderCommandType::Border => Self::Border(BorderContainer::from(*unsafe {
+                &mut *(value.config.borderElementConfig)
             })),
             RenderCommandType::Text => Self::Text(
                 <Clay_String as Into<&str>>::into(value.text).to_string(),
-                Text::from(unsafe { (&mut *(value.config.textElementConfig)).to_owned() }),
+                Text::from(*unsafe { &mut *(value.config.textElementConfig) }),
             ),
-            RenderCommandType::Image => Self::Image(Image::from(unsafe {
-                (&mut *(value.config.imageElementConfig)).to_owned()
+            RenderCommandType::Image => Self::Image(Image::from(*unsafe {
+                &mut *(value.config.imageElementConfig)
             })),
             RenderCommandType::ScissorStart => Self::ScissorStart(),
             RenderCommandType::ScissorEnd => Self::ScissorEnd(),
-            RenderCommandType::Custom => Self::Custom(Custom::from(unsafe {
-                (&mut *(value.config.customElementConfig)).to_owned()
+            RenderCommandType::Custom => Self::Custom(Custom::from(*unsafe {
+                &mut *(value.config.customElementConfig)
             })),
         }
     }


### PR DESCRIPTION
The current API doesn't make it easy to support RenderCommands in it's current state, making it mandatory to duplicate code/structs

So this new API should allow use on the two fronts. Some things were changed a bit, other were completly replaced.

PS. `Text` is still not working because we are waiting on what clay does with this