### PR TITLE
Remove extra warnings until they are fixed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
 fn main() {
-    cc::Build::new().file("build.c").compile("clay");
+    cc::Build::new()
+        .file("build.c")
+        .extra_warnings(false)
+        .compile("clay");
 }


### PR DESCRIPTION
Currently you get lots of warnings when you build `clay.h` This will disable them until they are fixed.