### PR TITLE
no-std fixes and removed String usage

### DIFF
--- a/src/render_commands.rs
+++ b/src/render_commands.rs
@@ -21,18 +21,18 @@ pub enum RenderCommandType {
 }
 
 #[derive(Debug, Clone)]
-pub enum RenderCommandConfig {
+pub enum RenderCommandConfig<'a> {
     None(),
     Rectangle(Rectangle),
     Border(BorderContainer),
-    Text(String, Text),
+    Text(&'a str, Text),
     Image(Image),
     ScissorStart(),
     ScissorEnd(),
     Custom(Custom),
 }
 
-impl From<&Clay_RenderCommand> for RenderCommandConfig {
+impl From<&Clay_RenderCommand> for RenderCommandConfig<'_> {
     fn from(value: &Clay_RenderCommand) -> Self {
         match unsafe { core::mem::transmute(value.commandType) } {
             RenderCommandType::None => Self::None(),
@@ -43,7 +43,7 @@ impl From<&Clay_RenderCommand> for RenderCommandConfig {
                 &mut *(value.config.borderElementConfig)
             })),
             RenderCommandType::Text => Self::Text(
-                <Clay_String as Into<&str>>::into(value.text).to_string(),
+                <Clay_String as Into<&str>>::into(value.text),
                 Text::from(*unsafe { &mut *(value.config.textElementConfig) }),
             ),
             RenderCommandType::Image => Self::Image(Image::from(*unsafe {
@@ -59,13 +59,13 @@ impl From<&Clay_RenderCommand> for RenderCommandConfig {
 }
 
 #[derive(Debug, Clone)]
-pub struct RenderCommand {
+pub struct RenderCommand<'a> {
     pub id: u32,
     pub bounding_box: BoundingBox,
-    pub config: RenderCommandConfig,
+    pub config: RenderCommandConfig<'a>,
 }
 
-impl From<Clay_RenderCommand> for RenderCommand {
+impl<'a> From<Clay_RenderCommand> for RenderCommand<'a> {
     fn from(value: Clay_RenderCommand) -> Self {
         Self {
             id: value.id,


### PR DESCRIPTION
Now we pass in a `&str` reference instead. Notice that doing  `.to_string()` will cause a memory allocation which isn't needed here. In order to fix this correctly I had to introduce lifetimes to tell the compiler how the string lives on, but nothing that was a big hurdle to implement.