### PR TITLE
Preparation for more tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         elif [ "${{ matrix.feature }}" = "debug" ]; then
           cargo build --features debug
         else
-          cargo test;
+          cargo test -- --test-threads=1;
         fi
       if: runner.os != 'Windows'
 
@@ -73,7 +73,7 @@ jobs:
         ) else if "%matrix.feature%"=="debug" (
           cargo build --features debug
         ) else (
-          cargo test
+          cargo test -- --test-threads=1
         )
       if: runner.os == 'Windows'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         elif [ "${{ matrix.feature }}" = "debug" ]; then
           cargo build --features debug
         else
-          cargo test -- --test-threads=1;
+          cargo test;
         fi
       if: runner.os != 'Windows'
 
@@ -73,7 +73,7 @@ jobs:
         ) else if "%matrix.feature%"=="debug" (
           cargo build --features debug
         ) else (
-          cargo test -- --test-threads=1
+          cargo test
         )
       if: runner.os == 'Windows'
 


### PR DESCRIPTION
When we start adding more tests we will run into the issue that `Clay` is single threaded. This make sure that our tests will run correctly.