### PR TITLE
Fixed so Windows compiles again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
         feature: [default, debug, no-std]
 

--- a/build.cpp
+++ b/build.cpp
@@ -1,0 +1,3 @@
+
+#define CLAY_IMPLEMENTATION
+#include "clay.h"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,15 @@
 fn main() {
-    cc::Build::new()
-        .file("build.c")
-        .extra_warnings(false)
-        .compile("clay");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target_os == "windows" {
+        cc::Build::new()
+            .file("build.cpp")
+            .std("c++20")
+            .compile("clay");
+    } else {
+        cc::Build::new()
+            .file("build.c")
+            .extra_warnings(false)
+            .compile("clay");
+    }
 }


### PR DESCRIPTION
In order to build Windows I had to add an extra build.cpp just for Windows (setting `compile as cpp` in `cc` didn't work) and this file is small is just used for compiling `clay.h` so I think it makes sense to just have it twice.
The only way I was able to get `Clay` compiling was as cpp with `std++20` enabled so that is what I will use for it.