### PR TITLE
`Color::rgb` ,`rgba`, `u_rgb` and `u_rgba` are now `const`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -10,10 +10,10 @@ pub struct Color {
 }
 
 impl Color {
-    pub fn rgb(r: f32, g: f32, b: f32) -> Self {
+    pub const fn rgb(r: f32, g: f32, b: f32) -> Self {
         Self { r, g, b, a: 255.0 }
     }
-    pub fn rgba(r: f32, g: f32, b: f32, a: f32) -> Self {
+    pub const fn rgba(r: f32, g: f32, b: f32, a: f32) -> Self {
         Self { r, g, b, a }
     }
 
@@ -22,7 +22,7 @@ impl Color {
     /// use clay_layout::color::Color;
     /// assert_eq!(Color::rgb(255.0, 255.0, 255.0), Color::u_rgb(0xFF, 0xFF, 0xFF));
     /// ```
-    pub fn u_rgb(r: u8, g: u8, b: u8) -> Self {
+    pub const fn u_rgb(r: u8, g: u8, b: u8) -> Self {
         Self::rgb(r as _, g as _, b as _)
     }
     /// Allows using hex values to build colors
@@ -30,7 +30,7 @@ impl Color {
     /// use clay_layout::color::Color;
     /// assert_eq!(Color::rgba(255.0, 255.0, 255.0, 255.0), Color::u_rgba(0xFF, 0xFF, 0xFF, 0xFF));
     /// ```
-    pub fn u_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+    pub const fn u_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self::rgba(r as _, g as _, b as _, a as _)
     }
 }


### PR DESCRIPTION
Added the `const` modifier to the `Color` constructor functions.