### PR TITLE
Added conversion from tuples for basic structures

### DIFF
--- a/examples/basic_rectangle.rs
+++ b/examples/basic_rectangle.rs
@@ -1,15 +1,13 @@
 use clay_layout::{
-    color::Color,
     elements::{rectangle::Rectangle, CornerRadius},
-    id::Id,
-    layout::{sizing::Sizing, Layout},
-    math::Dimensions,
+    fixed,
+    layout::Layout,
     Clay,
 };
 
 fn main() {
     // Create the clay instance
-    let clay = Clay::new(Dimensions::new(800., 600.));
+    let clay = Clay::new((800., 600.).into());
 
     // Begin the layout
     clay.begin();
@@ -18,14 +16,11 @@ fn main() {
     // The Layout makes the rectangle have a width and height of 50.
     clay.with(
         [
-            Layout::new()
-                .width(Sizing::Fixed(50.))
-                .height(Sizing::Fixed(50.))
-                .end(),
+            Layout::new().width(fixed!(50.)).height(fixed!(50.)).end(),
             Rectangle::new()
-                .color(Color::u_rgb(0xFF, 0x00, 0x00))
+                .color((0xFF, 0x00, 0x00).into())
                 .corner_radius(CornerRadius::All(5.))
-                .end(Id::new("Red Rectangle")),
+                .end("Red Rectangle".into()),
         ],
         |_| {},
     );

--- a/src/color.rs
+++ b/src/color.rs
@@ -45,3 +45,25 @@ impl From<Color> for Clay_Color {
         unsafe { core::mem::transmute(value) }
     }
 }
+
+impl From<(f32, f32, f32)> for Color {
+    fn from(value: (f32, f32, f32)) -> Self {
+        Self::rgb(value.0, value.1, value.2)
+    }
+}
+impl From<(f32, f32, f32, f32)> for Color {
+    fn from(value: (f32, f32, f32, f32)) -> Self {
+        Self::rgba(value.0, value.1, value.2, value.3)
+    }
+}
+
+impl From<(u8, u8, u8)> for Color {
+    fn from(value: (u8, u8, u8)) -> Self {
+        Self::u_rgb(value.0, value.1, value.2)
+    }
+}
+impl From<(u8, u8, u8, u8)> for Color {
+    fn from(value: (u8, u8, u8, u8)) -> Self {
+        Self::u_rgba(value.0, value.1, value.2, value.3)
+    }
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -41,3 +41,9 @@ impl From<Clay_ElementId> for Id<'_> {
         }
     }
 }
+
+impl<'a> From<&'a str> for Id<'a> {
+    fn from(value: &'a str) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/layout/alignment.rs
+++ b/src/layout/alignment.rs
@@ -45,3 +45,9 @@ impl From<Alignment> for Clay_ChildAlignment {
         }
     }
 }
+
+impl From<(LayoutAlignmentX, LayoutAlignmentY)> for Alignment {
+    fn from(other: (LayoutAlignmentX, LayoutAlignmentY)) -> Self {
+        Self::new(other.0, other.1)
+    }
+}

--- a/src/layout/padding.rs
+++ b/src/layout/padding.rs
@@ -28,3 +28,9 @@ impl From<Padding> for Clay_Padding {
         }
     }
 }
+
+impl From<(u16, u16)> for Padding {
+    fn from(other: (u16, u16)) -> Self {
+        Self::new(other.0, other.1)
+    }
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -24,6 +24,12 @@ impl From<Vector2> for Clay_Vector2 {
     }
 }
 
+impl From<(f32, f32)> for Vector2 {
+    fn from(value: (f32, f32)) -> Self {
+        Self::new(value.0, value.1)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[repr(C)]
 pub struct Dimensions {
@@ -45,6 +51,12 @@ impl From<Clay_Dimensions> for Dimensions {
 impl From<Dimensions> for Clay_Dimensions {
     fn from(value: Dimensions) -> Self {
         unsafe { core::mem::transmute(value) }
+    }
+}
+
+impl From<(f32, f32)> for Dimensions {
+    fn from(value: (f32, f32)) -> Self {
+        Self::new(value.0, value.1)
     }
 }
 


### PR DESCRIPTION
This pull request implements conversion from tuples for the following structures:

- **Color**
- **Id**
- **Alignment**
- **Padding**
- **Vector2**
- **Dimensions**


I believee these changes help make the API cleaner. (see the updated `basic_rectangle.rs` file for an example)
