### PR TITLE
Id now returns TypedConfig

### DIFF
--- a/examples/basic_rectangle.rs
+++ b/examples/basic_rectangle.rs
@@ -1,6 +1,7 @@
 use clay_layout::{
     elements::{rectangle::Rectangle, CornerRadius},
     fixed,
+    id::Id,
     layout::Layout,
     Clay,
 };
@@ -16,11 +17,12 @@ fn main() {
     // The Layout makes the rectangle have a width and height of 50.
     clay.with(
         [
+            Id::new("red_rectangle"),
             Layout::new().width(fixed!(50.)).height(fixed!(50.)).end(),
             Rectangle::new()
                 .color((0xFF, 0x00, 0x00).into())
                 .corner_radius(CornerRadius::All(5.))
-                .end("Red Rectangle".into()),
+                .end(),
         ],
         |_| {},
     );

--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -94,8 +94,8 @@ impl BorderContainer {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreBorderElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreBorderElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -2,8 +2,7 @@ use crate::{
     bindings::*,
     color::Color,
     elements::{CornerRadius, ElementConfigType},
-    id::Id,
-    TypedConfig,
+    mem, TypedConfig,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -95,12 +94,12 @@ impl BorderContainer {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreBorderElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreBorderElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::BorderContainer as _,
         }
     }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -1,9 +1,8 @@
 use crate::{
     bindings::*,
     elements::ElementConfigType,
-    id::Id,
     math::{Dimensions, Vector2},
-    TypedConfig,
+    mem, TypedConfig,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,12 +83,12 @@ impl FloatingContainer {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreFloatingElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreFloatingElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::FloatingContainer as _,
         }
     }

--- a/src/elements/containers/floating.rs
+++ b/src/elements/containers/floating.rs
@@ -83,8 +83,8 @@ impl FloatingContainer {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreFloatingElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreFloatingElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/elements/containers/scroll.rs
+++ b/src/elements/containers/scroll.rs
@@ -21,8 +21,8 @@ impl ScrollContainer {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreScrollElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreScrollElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/elements/containers/scroll.rs
+++ b/src/elements/containers/scroll.rs
@@ -1,4 +1,4 @@
-use crate::{bindings::*, elements::ElementConfigType, id::Id, TypedConfig};
+use crate::{bindings::*, elements::ElementConfigType, mem, TypedConfig};
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct ScrollContainer {
@@ -21,12 +21,12 @@ impl ScrollContainer {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreScrollElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreScrollElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::ScrollContainer as _,
         }
     }

--- a/src/elements/custom.rs
+++ b/src/elements/custom.rs
@@ -20,8 +20,8 @@ impl Custom {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreCustomElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreCustomElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/elements/custom.rs
+++ b/src/elements/custom.rs
@@ -1,6 +1,6 @@
 use core::{ffi::c_void, ptr};
 
-use crate::{bindings::*, id::Id, DataRef, TypedConfig};
+use crate::{bindings::*, mem, DataRef, TypedConfig};
 
 use super::ElementConfigType;
 
@@ -20,12 +20,12 @@ impl Custom {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreCustomElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreCustomElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::Image as _,
         }
     }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -26,8 +26,8 @@ impl Image {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreImageElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreImageElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_void;
 
-use crate::{bindings::*, id::Id, math::Dimensions, DataRef, TypedConfig};
+use crate::{bindings::*, math::Dimensions, mem, DataRef, TypedConfig};
 
 use super::ElementConfigType;
 
@@ -26,12 +26,12 @@ impl Image {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreImageElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreImageElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::Image as _,
         }
     }

--- a/src/elements/rectangle.rs
+++ b/src/elements/rectangle.rs
@@ -1,4 +1,4 @@
-use crate::{bindings::*, color::Color, id::Id, TypedConfig};
+use crate::{bindings::*, color::Color, mem, TypedConfig};
 
 use super::{CornerRadius, ElementConfigType};
 
@@ -23,12 +23,12 @@ impl Rectangle {
         self
     }
 
-    pub fn end(&self, id: Id) -> TypedConfig {
-        let memory = unsafe { Clay__StoreRectangleElementConfig((*self).into()) };
+    pub fn end(self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreRectangleElementConfig((self).into()) };
 
         TypedConfig {
             config_memory: memory as _,
-            id: id.into(),
+            id: mem::zeroed_init(),
             config_type: ElementConfigType::Rectangle as _,
         }
     }

--- a/src/elements/rectangle.rs
+++ b/src/elements/rectangle.rs
@@ -23,8 +23,8 @@ impl Rectangle {
         self
     }
 
-    pub fn end(self) -> TypedConfig {
-        let memory = unsafe { Clay__StoreRectangleElementConfig((self).into()) };
+    pub fn end(&self) -> TypedConfig {
+        let memory = unsafe { Clay__StoreRectangleElementConfig((*self).into()) };
 
         TypedConfig {
             config_memory: memory as _,

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,49 +1,25 @@
-use crate::bindings::*;
+use crate::{bindings::*, ElementConfigType, TypedConfig};
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Id<'a> {
-    pub id: u32,
-    pub offset: u32,
-    pub base_id: u32,
-    pub string_id: &'a str,
-}
+pub struct Id;
 
-impl<'a> Id<'a> {
+impl Id {
     /// Creates a clay id using the `label`
-    pub fn new(label: &'a str) -> Self {
-        unsafe { Clay__HashString(label.into(), 0, 0) }.into()
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(label: &str) -> TypedConfig {
+        Self::new_index(label, 0)
     }
 
     /// Creates a clay id using the `label` and the `index`
-    pub fn new_index(label: &'a str, index: u32) -> Self {
-        unsafe { Clay__HashString(label.into(), index, 0) }.into()
+    pub fn new_index(label: &str, index: u32) -> TypedConfig {
+        Self::new_index_internal(label, index)
     }
-}
 
-impl From<Id<'_>> for Clay_ElementId {
-    fn from(value: Id) -> Self {
-        Self {
-            id: value.id,
-            offset: value.offset,
-            baseId: value.base_id,
-            stringId: value.string_id.into(),
+    fn new_index_internal(label: &str, index: u32) -> TypedConfig {
+        let id = unsafe { Clay__HashString(label.into(), index, 0) };
+        TypedConfig {
+            config_memory: core::ptr::null_mut(),
+            id,
+            config_type: ElementConfigType::Id as _,
         }
-    }
-}
-
-impl From<Clay_ElementId> for Id<'_> {
-    fn from(value: Clay_ElementId) -> Self {
-        Self {
-            id: value.id,
-            offset: value.offset,
-            base_id: value.baseId,
-            string_id: value.stringId.into(),
-        }
-    }
-}
-
-impl<'a> From<&'a str> for Id<'a> {
-    fn from(value: &'a str) -> Self {
-        Self::new(value)
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -5,12 +5,12 @@ pub struct Id;
 impl Id {
     /// Creates a clay id using the `label`
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(label: &str) -> TypedConfig {
+    pub fn new(label: &'static str) -> TypedConfig {
         Self::new_index(label, 0)
     }
 
     /// Creates a clay id using the `label` and the `index`
-    pub fn new_index(label: &str, index: u32) -> TypedConfig {
+    pub fn new_index(label: &'static str, index: u32) -> TypedConfig {
         Self::new_index_internal(label, index)
     }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -14,7 +14,7 @@ impl Id {
         Self::new_index_internal(label, index)
     }
 
-    fn new_index_internal(label: &str, index: u32) -> TypedConfig {
+    fn new_index_internal(label: &'static str, index: u32) -> TypedConfig {
         let id = unsafe { Clay__HashString(label.into(), index, 0) };
         TypedConfig {
             config_memory: core::ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ mod mem;
 
 use elements::{text::TextElementConfig, ElementConfigType};
 use errors::Error;
-use id::Id;
 use math::{Dimensions, Vector2};
 use render_commands::RenderCommand;
 
@@ -193,8 +192,8 @@ impl<'a> Clay<'a> {
         unsafe { Clay_Hovered() }
     }
 
-    pub fn pointer_over(&self, id: Id) -> bool {
-        unsafe { Clay_PointerOver(id.into()) }
+    pub fn pointer_over(&self, cfg: TypedConfig) -> bool {
+        unsafe { Clay_PointerOver(cfg.id) }
     }
 
     pub fn begin(&self) {
@@ -296,27 +295,25 @@ mod tests {
 
         clay.with(
             [
+                Id::new("parent_rect"),
                 Layout::new()
                     .width(Sizing::Fixed(100.0))
                     .height(Sizing::Fixed(100.0))
                     .padding(Padding::new(10, 10))
                     .end(),
-                Rectangle::new()
-                    .color(Color::rgb(255., 255., 255.))
-                    .end(Id::new("parent_rect")),
+                Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
                 // FloatingContainer::new().end(Id::new("tegfddgftds"))
             ],
             |clay| {
                 clay.with(
                     [
+                        Id::new("rect_under_rect"),
                         Layout::new()
                             .width(Sizing::Fixed(100.0))
                             .height(Sizing::Fixed(100.0))
                             .padding(Padding::new(10, 10))
                             .end(),
-                        Rectangle::new()
-                            .color(Color::rgb(255., 255., 255.))
-                            .end(Id::new("rect_under_rect")),
+                        Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
                     ],
                     |_clay| {},
                 );
@@ -331,22 +328,22 @@ mod tests {
         );
         clay.with(
             [
+                Id::new_index("Border_container", 1),
                 Layout::new().padding(Padding::new(16, 16)).end(),
                 BorderContainer::new()
                     .all_directions(2, Color::rgb(255., 255., 0.))
                     .corner_radius(CornerRadius::All(25.))
-                    .end(Id::new_index("Border_container", 1)),
+                    .end(),
             ],
             |clay| {
                 clay.with(
                     [
+                        Id::new("rect_under_border"),
                         Layout::new()
                             .width(Sizing::Fixed(50.0))
                             .height(Sizing::Fixed(50.0))
                             .end(),
-                        Rectangle::new()
-                            .color(Color::rgb(0., 255., 255.))
-                            .end(Id::new("rect_under_border")),
+                        Rectangle::new().color(Color::rgb(0., 255., 255.)).end(),
                     ],
                     |_clay| {},
                 );


### PR DESCRIPTION
This changes how IDs are handled. They now matches closer to the Odin bindings in that they don't depend on other primitives being added during the setup.

Also changed so only `static str` are accepted to to `Id::new(...)` to enforce proper lifetimes.