### PR TITLE
Added new padding & boundingbox access

### DIFF
--- a/clay.h
+++ b/clay.h
@@ -70,6 +70,8 @@
 
 #define CLAY_CORNER_RADIUS(radius) (CLAY__INIT(Clay_CornerRadius) { radius, radius, radius, radius })
 
+#define CLAY_PADDING_ALL(padding) CLAY__CONFIG_WRAPPER(Clay_Padding, { padding, padding, padding, padding })
+
 #define CLAY_SIZING_FIT(...) (CLAY__INIT(Clay_SizingAxis) { .size = { .minMax = { __VA_ARGS__ } }, .type = CLAY__SIZING_TYPE_FIT })
 
 #define CLAY_SIZING_GROW(...) (CLAY__INIT(Clay_SizingAxis) { .size = { .minMax = { __VA_ARGS__ } }, .type = CLAY__SIZING_TYPE_GROW })
@@ -289,8 +291,10 @@ CLAY__TYPEDEF(Clay_Sizing, struct {
 });
 
 CLAY__TYPEDEF(Clay_Padding, struct {
-    uint16_t x;
-    uint16_t y;
+    uint16_t left;
+    uint16_t right;
+    uint16_t top;
+    uint16_t bottom;
 });
 
 CLAY__TYPEDEF(Clay_LayoutConfig, struct {
@@ -399,14 +403,18 @@ CLAY__TYPEDEF(Clay_Border, struct {
     Clay_Color color;
 });
 
-CLAY__TYPEDEF(Clay_BorderElementConfig, struct {
+struct Clay_BorderElementConfig {
     Clay_Border left;
     Clay_Border right;
     Clay_Border top;
     Clay_Border bottom;
     Clay_Border betweenChildren;
     Clay_CornerRadius cornerRadius;
-});
+    #ifdef CLAY_EXTEND_CONFIG_BORDER
+    CLAY_EXTEND_CONFIG_BORDER
+    #endif
+};
+CLAY__TYPEDEF(Clay_BorderElementConfig, struct Clay_BorderElementConfig);
 
 CLAY__TYPEDEF(Clay_ElementConfigUnion, union {
     Clay_RectangleElementConfig *rectangleElementConfig;
@@ -432,6 +440,13 @@ CLAY__TYPEDEF(Clay_ScrollContainerData, struct {
     Clay_Dimensions contentDimensions;
     Clay_ScrollElementConfig config;
     // Indicates whether an actual scroll container matched the provided ID or if the default struct was returned.
+    bool found;
+});
+
+CLAY__TYPEDEF(Clay_ElementData, struct
+{
+    Clay_BoundingBox boundingBox;
+    // Indicates whether an actual Element matched the provided ID or if the default struct was returned.
     bool found;
 });
 
@@ -507,6 +522,7 @@ void Clay_BeginLayout(void);
 Clay_RenderCommandArray Clay_EndLayout(void);
 Clay_ElementId Clay_GetElementId(Clay_String idString);
 Clay_ElementId Clay_GetElementIdWithIndex(Clay_String idString, uint32_t index);
+Clay_ElementData Clay_GetElementData (Clay_ElementId id);
 bool Clay_Hovered(void);
 void Clay_OnHover(void (*onHoverFunction)(Clay_ElementId elementId, Clay_PointerData pointerData, intptr_t userData), intptr_t userData);
 bool Clay_PointerOver(Clay_ElementId elementId);
@@ -521,6 +537,7 @@ int32_t Clay_GetMaxElementCount(void);
 void Clay_SetMaxElementCount(int32_t maxElementCount);
 int32_t Clay_GetMaxMeasureTextCacheWordCount(void);
 void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount);
+void Clay_ResetMeasureTextCache(void);
 
 // Internal API functions required by macros
 void Clay__OpenElement(void);
@@ -1209,6 +1226,7 @@ Clay__MeasuredWord *Clay__MeasuredWordArray_Add(Clay__MeasuredWordArray *array, 
 CLAY__TYPEDEF(Clay__MeasureTextCacheItem, struct {
     Clay_Dimensions unwrappedDimensions;
     int32_t measuredWordsStartIndex;
+    bool containsNewlines;
     // Hash map data
     uint32_t id;
     int32_t nextIndex;
@@ -1326,7 +1344,7 @@ CLAY__TYPEDEF(Clay__LayoutElementTreeRoot, struct {
 
 Clay__LayoutElementTreeRoot CLAY__LAYOUT_ELEMENT_TREE_ROOT_DEFAULT = CLAY__DEFAULT_STRUCT;
 
-// __GENERATED__ template array_define,array_allocate,array_add,array_get TYPE=Clay__LayoutElementTreeRoot NAME=Clay__LayoutElementTreeRootArray DEFAULT_VALUE=&CLAY__LAYOUT_ELEMENT_TREE_ROOT_DEFAULT
+// __GENERATED__ template array_define,array_allocate,array_add,array_get,array_set TYPE=Clay__LayoutElementTreeRoot NAME=Clay__LayoutElementTreeRootArray DEFAULT_VALUE=&CLAY__LAYOUT_ELEMENT_TREE_ROOT_DEFAULT
 #pragma region generated
 CLAY__TYPEDEF(Clay__LayoutElementTreeRootArray, struct
 {
@@ -1346,6 +1364,12 @@ Clay__LayoutElementTreeRoot *Clay__LayoutElementTreeRootArray_Add(Clay__LayoutEl
 }
 Clay__LayoutElementTreeRoot *Clay__LayoutElementTreeRootArray_Get(Clay__LayoutElementTreeRootArray *array, int32_t index) {
     return Clay__Array_RangeCheck(index, array->length) ? &array->internalArray[index] : &CLAY__LAYOUT_ELEMENT_TREE_ROOT_DEFAULT;
+}
+void Clay__LayoutElementTreeRootArray_Set(Clay__LayoutElementTreeRootArray *array, int32_t index, Clay__LayoutElementTreeRoot value) {
+	if (Clay__Array_RangeCheck(index, array->capacity)) {
+		array->internalArray[index] = value;
+		array->length = index < array->length ? array->length : index + 1;
+	}
 }
 #pragma endregion
 // __GENERATED__ template
@@ -1381,7 +1405,7 @@ struct Clay_Context {
     bool externalScrollHandlingEnabled;
     uint32_t debugSelectedElementId;
     uint32_t generation;
-    uint64_t arenaResetOffset;
+    uintptr_t arenaResetOffset;
     Clay_Arena internalArena;
     // Layout Elements / Render Commands
     Clay_LayoutElementArray layoutElements;
@@ -1668,6 +1692,7 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
 
     int32_t start = 0;
     int32_t end = 0;
+    float lineWidth = 0;
     float measuredWidth = 0;
     float measuredHeight = 0;
     float spaceWidth = Clay__MeasureText(&CLAY__SPACECHAR, config).width;
@@ -1689,18 +1714,22 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
             int32_t length = end - start;
             Clay_String word = { .length = length, .chars = &text->chars[start] };
             Clay_Dimensions dimensions = Clay__MeasureText(&word, config);
+            measuredHeight = CLAY__MAX(measuredHeight, dimensions.height);
             if (current == ' ') {
                 dimensions.width += spaceWidth;
                 previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length + 1, .width = dimensions.width, .next = -1 }, previousWord);
+                lineWidth += dimensions.width;
             }
             if (current == '\n') {
-                if (length > 1) {
+                if (length > 0) {
                     previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length, .width = dimensions.width, .next = -1 }, previousWord);
                 }
                 previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = end + 1, .length = 0, .width = 0, .next = -1 }, previousWord);
+                lineWidth += dimensions.width;
+                measuredWidth = CLAY__MAX(lineWidth, measuredWidth);
+                measured->containsNewlines = true;
+                lineWidth = 0;
             }
-            measuredWidth += dimensions.width;
-            measuredHeight = dimensions.height;
             start = end + 1;
         }
         end++;
@@ -1709,9 +1738,11 @@ Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_Text
         Clay_String lastWord = { .length = end - start, .chars = &text->chars[start] };
         Clay_Dimensions dimensions = Clay__MeasureText(&lastWord, config);
         Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = end - start, .width = dimensions.width, .next = -1 }, previousWord);
-        measuredWidth += dimensions.width;
-        measuredHeight = dimensions.height;
+        lineWidth += dimensions.width;
+        measuredHeight = CLAY__MAX(measuredHeight, dimensions.height);
     }
+    measuredWidth = CLAY__MAX(lineWidth, measuredWidth);
+
     measured->measuredWordsStartIndex = tempWord.next;
     measured->unwrappedDimensions.width = measuredWidth;
     measured->unwrappedDimensions.height = measuredHeight;
@@ -1902,18 +1933,18 @@ void Clay__CloseElement(void) {
     // Attach children to the current open element
     openLayoutElement->childrenOrTextContent.children.elements = &context->layoutElementChildren.internalArray[context->layoutElementChildren.length];
     if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
-        openLayoutElement->dimensions.width = (float)layoutConfig->padding.x * 2;
+        openLayoutElement->dimensions.width = (float)(layoutConfig->padding.left + layoutConfig->padding.right);
         for (int32_t i = 0; i < openLayoutElement->childrenOrTextContent.children.length; i++) {
             int32_t childIndex = Clay__int32_tArray_Get(&context->layoutElementChildrenBuffer, (int)context->layoutElementChildrenBuffer.length - openLayoutElement->childrenOrTextContent.children.length + i);
             Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, childIndex);
             openLayoutElement->dimensions.width += child->dimensions.width;
-            openLayoutElement->dimensions.height = CLAY__MAX(openLayoutElement->dimensions.height, child->dimensions.height + layoutConfig->padding.y * 2);
+            openLayoutElement->dimensions.height = CLAY__MAX(openLayoutElement->dimensions.height, child->dimensions.height + layoutConfig->padding.top + layoutConfig->padding.bottom);
             // Minimum size of child elements doesn't matter to scroll containers as they can shrink and hide their contents
             if (!elementHasScrollHorizontal) {
                 openLayoutElement->minDimensions.width += child->minDimensions.width;
             }
             if (!elementHasScrollVertical) {
-                openLayoutElement->minDimensions.height = CLAY__MAX(openLayoutElement->minDimensions.height, child->minDimensions.height + layoutConfig->padding.y * 2);
+                openLayoutElement->minDimensions.height = CLAY__MAX(openLayoutElement->minDimensions.height, child->minDimensions.height + layoutConfig->padding.top + layoutConfig->padding.bottom);
             }
             Clay__int32_tArray_Add(&context->layoutElementChildren, childIndex);
         }
@@ -1922,18 +1953,18 @@ void Clay__CloseElement(void) {
         openLayoutElement->minDimensions.width += childGap;
     }
     else if (layoutConfig->layoutDirection == CLAY_TOP_TO_BOTTOM) {
-        openLayoutElement->dimensions.height = (float)layoutConfig->padding.y * 2;
+        openLayoutElement->dimensions.height = (float)(layoutConfig->padding.top + layoutConfig->padding.bottom);
         for (int32_t i = 0; i < openLayoutElement->childrenOrTextContent.children.length; i++) {
             int32_t childIndex = Clay__int32_tArray_Get(&context->layoutElementChildrenBuffer, (int)context->layoutElementChildrenBuffer.length - openLayoutElement->childrenOrTextContent.children.length + i);
             Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, childIndex);
             openLayoutElement->dimensions.height += child->dimensions.height;
-            openLayoutElement->dimensions.width = CLAY__MAX(openLayoutElement->dimensions.width, child->dimensions.width + layoutConfig->padding.x * 2);
+            openLayoutElement->dimensions.width = CLAY__MAX(openLayoutElement->dimensions.width, child->dimensions.width + layoutConfig->padding.left + layoutConfig->padding.right);
             // Minimum size of child elements doesn't matter to scroll containers as they can shrink and hide their contents
             if (!elementHasScrollVertical) {
                 openLayoutElement->minDimensions.height += child->minDimensions.height;
             }
             if (!elementHasScrollHorizontal) {
-                openLayoutElement->minDimensions.width = CLAY__MAX(openLayoutElement->minDimensions.width, child->minDimensions.width + layoutConfig->padding.x * 2);
+                openLayoutElement->minDimensions.width = CLAY__MAX(openLayoutElement->minDimensions.width, child->minDimensions.width + layoutConfig->padding.left + layoutConfig->padding.right);
             }
             Clay__int32_tArray_Add(&context->layoutElementChildren, childIndex);
         }
@@ -2088,13 +2119,16 @@ void Clay__CompressChildrenAlongAxis(bool xAxis, float totalSizeToDistribute, Cl
     Clay__int32_tArray largestContainers = context->openClipElementStack;
     largestContainers.length = 0;
 
-    while (totalSizeToDistribute > 0) {
+    while (totalSizeToDistribute > 0.1) {
         float largestSize = 0;
         float targetSize = 0;
         for (int32_t i = 0; i < resizableContainerBuffer.length; ++i) {
             Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_Get(&resizableContainerBuffer, i));
+            if (!xAxis && Clay__ElementHasConfig(childElement, CLAY__ELEMENT_CONFIG_TYPE_IMAGE)) {
+                continue;
+            }
             float childSize = xAxis ? childElement->dimensions.width : childElement->dimensions.height;
-            if (childSize == largestSize) {
+            if ((childSize - largestSize) < 0.1 && (childSize - largestSize) > -0.1) {
                 Clay__int32_tArray_Add(&largestContainers, Clay__int32_tArray_Get(&resizableContainerBuffer, i));
             } else if (childSize > largestSize) {
                 targetSize = largestSize;
@@ -2161,8 +2195,8 @@ void Clay__SizeContainersAlongAxis(bool xAxis) {
             Clay_LayoutConfig *parentStyleConfig = parent->layoutConfig;
             int32_t growContainerCount = 0;
             float parentSize = xAxis ? parent->dimensions.width : parent->dimensions.height;
-            float parentPadding = (float)(xAxis ? parent->layoutConfig->padding.x : parent->layoutConfig->padding.y);
-            float innerContentSize = 0, growContainerContentSize = 0, totalPaddingAndChildGaps = parentPadding * 2;
+            float parentPadding = (float)(xAxis ? (parent->layoutConfig->padding.left + parent->layoutConfig->padding.right) : (parent->layoutConfig->padding.top + parent->layoutConfig->padding.bottom));
+            float innerContentSize = 0, growContainerContentSize = 0, totalPaddingAndChildGaps = parentPadding;
             bool sizingAlongAxis = (xAxis && parentStyleConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) || (!xAxis && parentStyleConfig->layoutDirection == CLAY_TOP_TO_BOTTOM);
             resizableContainerBuffer.length = 0;
             float parentChildGap = parentStyleConfig->childGap;
@@ -2217,7 +2251,7 @@ void Clay__SizeContainersAlongAxis(bool xAxis) {
             }
 
             if (sizingAlongAxis) {
-                float sizeToDistribute = parentSize - parentPadding * 2 - innerContentSize;
+                float sizeToDistribute = parentSize - parentPadding - innerContentSize;
                 // The content is too large, compress the children as much as possible
                 if (sizeToDistribute < 0) {
                     // If the parent can scroll in the axis direction in this direction, don't compress children, just leave them alone
@@ -2262,7 +2296,7 @@ void Clay__SizeContainersAlongAxis(bool xAxis) {
                     }
 
                     // If we're laying out the children of a scroll panel, grow containers expand to the height of the inner content, not the outer container
-                    float maxSize = parentSize - parentPadding * 2;
+                    float maxSize = parentSize - parentPadding;
                     if (Clay__ElementHasConfig(parent, CLAY__ELEMENT_CONFIG_TYPE_SCROLL_CONTAINER)) {
                         Clay_ScrollElementConfig *scrollElementConfig = Clay__FindElementConfigWithType(parent, CLAY__ELEMENT_CONFIG_TYPE_SCROLL_CONTAINER).scrollElementConfig;
                         if (((xAxis && scrollElementConfig->horizontal) || (!xAxis && scrollElementConfig->vertical))) {
@@ -2354,7 +2388,7 @@ void Clay__CalculateFinalLayout() {
         float lineHeight = textConfig->lineHeight > 0 ? (float)textConfig->lineHeight : textElementData->preferredDimensions.height;
         int32_t lineLengthChars = 0;
         int32_t lineStartOffset = 0;
-        if (textElementData->preferredDimensions.width <= containerElement->dimensions.width) {
+        if (!measureTextCacheItem->containsNewlines && textElementData->preferredDimensions.width <= containerElement->dimensions.width) {
             Clay__WrappedTextLineArray_Add(&context->wrappedTextLines, CLAY__INIT(Clay__WrappedTextLine) { containerElement->dimensions,  textElementData->text });
             textElementData->wrappedLines.length++;
             continue;
@@ -2439,12 +2473,12 @@ void Clay__CalculateFinalLayout() {
             // Resize any parent containers that have grown in height along their non layout axis
             for (int32_t j = 0; j < currentElement->childrenOrTextContent.children.length; ++j) {
                 Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[j]);
-                float childHeightWithPadding = CLAY__MAX(childElement->dimensions.height + layoutConfig->padding.y * 2, currentElement->dimensions.height);
+                float childHeightWithPadding = CLAY__MAX(childElement->dimensions.height + layoutConfig->padding.top + layoutConfig->padding.bottom, currentElement->dimensions.height);
                 currentElement->dimensions.height = CLAY__MIN(CLAY__MAX(childHeightWithPadding, layoutConfig->sizing.height.size.minMax.min), layoutConfig->sizing.height.size.minMax.max);
             }
         } else if (layoutConfig->layoutDirection == CLAY_TOP_TO_BOTTOM) {
             // Resizing along the layout axis
-            float contentHeight = (float)layoutConfig->padding.y * 2;
+            float contentHeight = (float)(layoutConfig->padding.top + layoutConfig->padding.bottom);
             for (int32_t j = 0; j < currentElement->childrenOrTextContent.children.length; ++j) {
                 Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[j]);
                 contentHeight += childElement->dimensions.height;
@@ -2456,6 +2490,20 @@ void Clay__CalculateFinalLayout() {
 
     // Calculate sizing along the Y axis
     Clay__SizeContainersAlongAxis(false);
+
+    // Sort tree roots by z-index
+    int32_t sortMax = context->layoutElementTreeRoots.length - 1;
+    while (sortMax > 0) { // todo dumb bubble sort
+        for (int32_t i = 0; i < sortMax; ++i) {
+            Clay__LayoutElementTreeRoot current = *Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, i);
+            Clay__LayoutElementTreeRoot next = *Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, i + 1);
+            if (next.zIndex < current.zIndex) {
+                Clay__LayoutElementTreeRootArray_Set(&context->layoutElementTreeRoots, i, next);
+                Clay__LayoutElementTreeRootArray_Set(&context->layoutElementTreeRoots, i + 1, current);
+            }
+        }
+        sortMax--;
+    }
 
     // Calculate final positions and generate render commands
     context->renderCommands.length = 0;
@@ -2549,7 +2597,7 @@ void Clay__CalculateFinalLayout() {
                 });
             }
         }
-        Clay__LayoutElementTreeNodeArray_Add(&dfsBuffer, CLAY__INIT(Clay__LayoutElementTreeNode) { .layoutElement = rootElement, .position = rootPosition, .nextChildOffset = { .x = (float)rootElement->layoutConfig->padding.x, .y = (float)rootElement->layoutConfig->padding.y } });
+        Clay__LayoutElementTreeNodeArray_Add(&dfsBuffer, CLAY__INIT(Clay__LayoutElementTreeNode) { .layoutElement = rootElement, .position = rootPosition, .nextChildOffset = { .x = (float)rootElement->layoutConfig->padding.left, .y = (float)rootElement->layoutConfig->padding.top } });
 
         context->treeNodeVisited.internalArray[0] = false;
         while (dfsBuffer.length > 0) {
@@ -2606,7 +2654,7 @@ void Clay__CalculateFinalLayout() {
                 for (int32_t elementConfigIndex = 0; elementConfigIndex < currentElement->elementConfigs.length; ++elementConfigIndex) {
                     sortedConfigIndexes[elementConfigIndex] = elementConfigIndex;
                 }
-                int32_t sortMax = currentElement->elementConfigs.length - 1;
+                sortMax = currentElement->elementConfigs.length - 1;
                 while (sortMax > 0) { // todo dumb bubble sort
                     for (int32_t i = 0; i < sortMax; ++i) {
                         int32_t current = sortedConfigIndexes[i];
@@ -2714,7 +2762,7 @@ void Clay__CalculateFinalLayout() {
                             contentSize.height = CLAY__MAX(contentSize.height, childElement->dimensions.height);
                         }
                         contentSize.width += (float)(CLAY__MAX(currentElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
-                        float extraSpace = currentElement->dimensions.width - (float)layoutConfig->padding.x * 2 - contentSize.width;
+                        float extraSpace = currentElement->dimensions.width - (float)(layoutConfig->padding.left + layoutConfig->padding.right) - contentSize.width;
                         switch (layoutConfig->childAlignment.x) {
                             case CLAY_ALIGN_X_LEFT: extraSpace = 0; break;
                             case CLAY_ALIGN_X_CENTER: extraSpace /= 2; break;
@@ -2728,7 +2776,7 @@ void Clay__CalculateFinalLayout() {
                             contentSize.height += childElement->dimensions.height;
                         }
                         contentSize.height += (float)(CLAY__MAX(currentElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
-                        float extraSpace = currentElement->dimensions.height - (float)layoutConfig->padding.y * 2 - contentSize.height;
+                        float extraSpace = currentElement->dimensions.height - (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) - contentSize.height;
                         switch (layoutConfig->childAlignment.y) {
                             case CLAY_ALIGN_Y_TOP: extraSpace = 0; break;
                             case CLAY_ALIGN_Y_CENTER: extraSpace /= 2; break;
@@ -2738,7 +2786,7 @@ void Clay__CalculateFinalLayout() {
                     }
 
                     if (scrollContainerData) {
-                        scrollContainerData->contentSize = CLAY__INIT(Clay_Dimensions) { contentSize.width + (float)layoutConfig->padding.x * 2, contentSize.height + (float)layoutConfig->padding.y * 2 };
+                        scrollContainerData->contentSize = CLAY__INIT(Clay_Dimensions) { contentSize.width + (float)(layoutConfig->padding.left + layoutConfig->padding.right), contentSize.height + (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) };
                     }
                 }
             }
@@ -2777,7 +2825,8 @@ void Clay__CalculateFinalLayout() {
                         Clay__AddRenderCommand(renderCommand);
                         if (borderConfig->betweenChildren.width > 0 && borderConfig->betweenChildren.color.a > 0) {
                             Clay_RectangleElementConfig *rectangleConfig = Clay__StoreRectangleElementConfig(CLAY__INIT(Clay_RectangleElementConfig) {.color = borderConfig->betweenChildren.color});
-                            Clay_Vector2 borderOffset = { (float)layoutConfig->padding.x, (float)layoutConfig->padding.y };
+                            float halfGap = layoutConfig->childGap / 2;
+                            Clay_Vector2 borderOffset = { (float)layoutConfig->padding.left - halfGap, (float)layoutConfig->padding.top - halfGap };
                             if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
                                 for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
                                     Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
@@ -2789,7 +2838,7 @@ void Clay__CalculateFinalLayout() {
                                             .commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
                                         });
                                     }
-                                    borderOffset.x += (childElement->dimensions.width + (float)layoutConfig->childGap / 2);
+                                    borderOffset.x += (childElement->dimensions.width + (float)layoutConfig->childGap);
                                 }
                             } else {
                                 for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
@@ -2802,7 +2851,7 @@ void Clay__CalculateFinalLayout() {
                                                 .commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
                                         });
                                     }
-                                    borderOffset.y += (childElement->dimensions.height + (float)layoutConfig->childGap / 2);
+                                    borderOffset.y += (childElement->dimensions.height + (float)layoutConfig->childGap);
                                 }
                             }
                         }
@@ -2827,16 +2876,16 @@ void Clay__CalculateFinalLayout() {
                     Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
                     // Alignment along non layout axis
                     if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
-                        currentElementTreeNode->nextChildOffset.y = currentElement->layoutConfig->padding.y;
-                        float whiteSpaceAroundChild = currentElement->dimensions.height - (float)currentElement->layoutConfig->padding.y * 2 - childElement->dimensions.height;
+                        currentElementTreeNode->nextChildOffset.y = currentElement->layoutConfig->padding.top;
+                        float whiteSpaceAroundChild = currentElement->dimensions.height - (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) - childElement->dimensions.height;
                         switch (layoutConfig->childAlignment.y) {
                             case CLAY_ALIGN_Y_TOP: break;
                             case CLAY_ALIGN_Y_CENTER: currentElementTreeNode->nextChildOffset.y += whiteSpaceAroundChild / 2; break;
                             case CLAY_ALIGN_Y_BOTTOM: currentElementTreeNode->nextChildOffset.y += whiteSpaceAroundChild; break;
                         }
                     } else {
-                        currentElementTreeNode->nextChildOffset.x = currentElement->layoutConfig->padding.x;
-                        float whiteSpaceAroundChild = currentElement->dimensions.width - (float)currentElement->layoutConfig->padding.x * 2 - childElement->dimensions.width;
+                        currentElementTreeNode->nextChildOffset.x = currentElement->layoutConfig->padding.left;
+                        float whiteSpaceAroundChild = currentElement->dimensions.width - (float)(layoutConfig->padding.left + layoutConfig->padding.right) - childElement->dimensions.width;
                         switch (layoutConfig->childAlignment.x) {
                             case CLAY_ALIGN_X_LEFT: break;
                             case CLAY_ALIGN_X_CENTER: currentElementTreeNode->nextChildOffset.x += whiteSpaceAroundChild / 2; break;
@@ -2854,7 +2903,7 @@ void Clay__CalculateFinalLayout() {
                     dfsBuffer.internalArray[newNodeIndex] = CLAY__INIT(Clay__LayoutElementTreeNode) {
                         .layoutElement = childElement,
                         .position = { childPosition.x, childPosition.y },
-                        .nextChildOffset = { .x = (float)childElement->layoutConfig->padding.x, .y = (float)childElement->layoutConfig->padding.y },
+                        .nextChildOffset = { .x = (float)childElement->layoutConfig->padding.left, .y = (float)childElement->layoutConfig->padding.top },
                     };
                     context->treeNodeVisited.internalArray[newNodeIndex] = false;
 
@@ -3009,12 +3058,12 @@ Clay__RenderDebugLayoutData Clay__RenderDebugLayoutElementsList(int32_t initialR
                 // Collisions and offscreen info
                 if (currentElementData) {
                     if (currentElementData->debugData->collision) {
-                        CLAY(CLAY_LAYOUT({ .padding = { 8, 2 } }), CLAY_BORDER_OUTSIDE_RADIUS(1, (CLAY__INIT(Clay_Color){177, 147, 8, 255}), 4)) {
+                        CLAY(CLAY_LAYOUT({ .padding = { 8, 8, 2, 2 } }), CLAY_BORDER_OUTSIDE_RADIUS(1, (CLAY__INIT(Clay_Color){177, 147, 8, 255}), 4)) {
                             CLAY_TEXT(CLAY_STRING("Duplicate ID"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }));
                         }
                     }
                     if (offscreen) {
-                        CLAY(CLAY_LAYOUT({ .padding = { 8, 2 } }), CLAY_BORDER_OUTSIDE_RADIUS(1, CLAY__DEBUGVIEW_COLOR_3, 4)) {
+                        CLAY(CLAY_LAYOUT({ .padding = { 8, 8, 2, 2 } }), CLAY_BORDER_OUTSIDE_RADIUS(1, CLAY__DEBUGVIEW_COLOR_3, 4)) {
                             CLAY_TEXT(CLAY_STRING("Offscreen"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }));
                         }
                     }
@@ -3028,7 +3077,7 @@ Clay__RenderDebugLayoutData Clay__RenderDebugLayoutElementsList(int32_t initialR
                     Clay__DebugElementConfigTypeLabelConfig config = Clay__DebugGetElementConfigTypeLabel(elementConfig->type);
                     Clay_Color backgroundColor = config.color;
                     backgroundColor.a = 90;
-                    CLAY(CLAY_LAYOUT({ .padding = { 8, 2 } }), CLAY_RECTANGLE({ .color = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4) }), CLAY_BORDER_OUTSIDE_RADIUS(1, config.color, 4)) {
+                    CLAY(CLAY_LAYOUT({ .padding = { 8, 8, 2, 2 } }), CLAY_RECTANGLE({ .color = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4) }), CLAY_BORDER_OUTSIDE_RADIUS(1, config.color, 4)) {
                         CLAY_TEXT(config.label, CLAY_TEXT_CONFIG({ .textColor = offscreen ? CLAY__DEBUGVIEW_COLOR_3 : CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
                     }
                 }
@@ -3050,7 +3099,7 @@ Clay__RenderDebugLayoutData Clay__RenderDebugLayoutElementsList(int32_t initialR
                 }
             } else if (currentElement->childrenOrTextContent.children.length > 0) {
                 Clay__OpenElement();
-                CLAY_LAYOUT({ .padding = { 8 , 0} });
+                CLAY_LAYOUT({ .padding = { 8 } });
                 Clay__ElementPostConfiguration();
                 Clay__OpenElement();
                 CLAY_BORDER({ .left = { .width = 1, .color = CLAY__DEBUGVIEW_COLOR_3 }});
@@ -3120,8 +3169,8 @@ void Clay__RenderDebugViewElementConfigHeader(Clay_String elementId, Clay__Eleme
     Clay__DebugElementConfigTypeLabelConfig config = Clay__DebugGetElementConfigTypeLabel(type);
     Clay_Color backgroundColor = config.color;
     backgroundColor.a = 90;
-    CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT + 8)}, .padding = { .x = CLAY__DEBUGVIEW_OUTER_PADDING }, .childAlignment = { .y = CLAY_ALIGN_Y_CENTER } })) {
-        CLAY(CLAY_LAYOUT({ .padding = { 8, 2 } }), CLAY_RECTANGLE({ .color = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4) }), CLAY_BORDER_OUTSIDE_RADIUS(1, config.color, 4)) {
+    CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0)}, .padding = CLAY_PADDING_ALL(CLAY__DEBUGVIEW_OUTER_PADDING), .childAlignment = { .y = CLAY_ALIGN_Y_CENTER } })) {
+        CLAY(CLAY_LAYOUT({ .padding = { 8, 8, 2, 2 } }), CLAY_RECTANGLE({ .color = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4) }), CLAY_BORDER_OUTSIDE_RADIUS(1, config.color, 4)) {
             CLAY_TEXT(config.label, CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
         }
         CLAY(CLAY_LAYOUT({ .sizing = { .width = CLAY_SIZING_GROW(0) } })) {}
@@ -3199,16 +3248,19 @@ void Clay__RenderDebugView() {
     Clay_TextElementConfig *infoTitleConfig = CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE });
     Clay_ElementId scrollId = Clay__HashString(CLAY_STRING("Clay__DebugViewOuterScrollPane"), 0, 0);
     float scrollYOffset = 0;
+    bool pointerInDebugView = context->pointerInfo.position.y < context->layoutDimensions.height - 300;
     for (int32_t i = 0; i < context->scrollContainerDatas.length; ++i) {
         Clay__ScrollContainerDataInternal *scrollContainerData = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
         if (scrollContainerData->elementId == scrollId.id) {
             if (!context->externalScrollHandlingEnabled) {
                 scrollYOffset = scrollContainerData->scrollPosition.y;
+            } else {
+                pointerInDebugView = context->pointerInfo.position.y + scrollContainerData->scrollPosition.y < context->layoutDimensions.height - 300;
             }
             break;
         }
     }
-    int32_t highlightedRow = context->pointerInfo.position.y < context->layoutDimensions.height - 300
+    int32_t highlightedRow = pointerInDebugView
             ? (int32_t)((context->pointerInfo.position.y - scrollYOffset) / (float)CLAY__DEBUGVIEW_ROW_HEIGHT) - 1
             : -1;
     if (context->pointerInfo.position.x < context->layoutDimensions.width - (float)Clay__debugViewWidth) {
@@ -3216,13 +3268,13 @@ void Clay__RenderDebugView() {
     }
     Clay__RenderDebugLayoutData layoutData = CLAY__DEFAULT_STRUCT;
     CLAY(CLAY_ID("Clay__DebugView"),
-        CLAY_FLOATING({ .parentId = Clay__HashString(CLAY_STRING("Clay__RootContainer"), 0, 0).id, .attachment = { .element = CLAY_ATTACH_POINT_LEFT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER }}),
+        CLAY_FLOATING({ .zIndex = 65000, .parentId = Clay__HashString(CLAY_STRING("Clay__RootContainer"), 0, 0).id, .attachment = { .element = CLAY_ATTACH_POINT_LEFT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER }}),
         CLAY_LAYOUT({ .sizing = { CLAY_SIZING_FIXED((float)Clay__debugViewWidth) , CLAY_SIZING_FIXED(context->layoutDimensions.height) }, .layoutDirection = CLAY_TOP_TO_BOTTOM }),
         CLAY_BORDER({ .bottom = { .width = 1, .color = CLAY__DEBUGVIEW_COLOR_3 }})
     ) {
-        CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 0}, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} }), CLAY_RECTANGLE({ .color = CLAY__DEBUGVIEW_COLOR_2 })) {
+        CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING }, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} }), CLAY_RECTANGLE({ .color = CLAY__DEBUGVIEW_COLOR_2 })) {
             CLAY_TEXT(CLAY_STRING("Clay Debug Tools"), infoTextConfig);
-            CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0), {0} } })) {}
+            CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0) } })) {}
             // Close button
             CLAY(CLAY_BORDER_OUTSIDE_RADIUS(1, (CLAY__INIT(Clay_Color){217,91,67,255}), 4),
                 CLAY_LAYOUT({ .sizing = {CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 10), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 10)}, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER} }),
@@ -3237,8 +3289,8 @@ void Clay__RenderDebugView() {
             CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .layoutDirection = CLAY_TOP_TO_BOTTOM }), CLAY_RECTANGLE({ .color = ((initialElementsLength + initialRootsLength) & 1) == 0 ? CLAY__DEBUGVIEW_COLOR_2 : CLAY__DEBUGVIEW_COLOR_1 })) {
                 Clay_ElementId panelContentsId = Clay__HashString(CLAY_STRING("Clay__DebugViewPaneOuter"), 0, 0);
                 // Element list
-                CLAY(Clay__AttachId(panelContentsId), CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }), CLAY_FLOATING({ .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH })) {
-                    CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .padding = {.x = CLAY__DEBUGVIEW_OUTER_PADDING }, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                CLAY(Clay__AttachId(panelContentsId), CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }), CLAY_FLOATING({ .zIndex = 65001, .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH })) {
+                    CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .padding = { CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING }, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                         layoutData = Clay__RenderDebugLayoutElementsList((int32_t)initialRootsLength, highlightedRow);
                     }
                 }
@@ -3267,9 +3319,9 @@ void Clay__RenderDebugView() {
                 CLAY_RECTANGLE({ .color = CLAY__DEBUGVIEW_COLOR_2 }),
                 CLAY_BORDER({ .betweenChildren = { .width = 1, .color = CLAY__DEBUGVIEW_COLOR_3 }})
             ) {
-                CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT + 8)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 0}, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
+                CLAY(CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT + 8)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING}, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
                     CLAY_TEXT(CLAY_STRING("Layout Config"), infoTextConfig);
-                    CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0), {0} } })) {}
+                    CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0) } })) {}
                     if (selectedItem->elementId.stringId.length != 0) {
                         CLAY_TEXT(selectedItem->elementId.stringId, infoTitleConfig);
                         if (selectedItem->elementId.offset != 0) {
@@ -3279,8 +3331,9 @@ void Clay__RenderDebugView() {
                         }
                     }
                 }
+                Clay_Padding attributeConfigPadding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 8, 8};
                 // Clay_LayoutConfig debug info
-                CLAY(CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                CLAY(CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                     // .boundingBox
                     CLAY_TEXT(CLAY_STRING("Bounding Box"), infoTitleConfig);
                     CLAY(CLAY_LAYOUT(CLAY__DEFAULT_STRUCT)) {
@@ -3311,10 +3364,14 @@ void Clay__RenderDebugView() {
                     // .padding
                     CLAY_TEXT(CLAY_STRING("Padding"), infoTitleConfig);
                     CLAY(CLAY_ID("Clay__DebugViewElementInfoPadding")) {
-                        CLAY_TEXT(CLAY_STRING("{ x: "), infoTextConfig);
-                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.x), infoTextConfig);
-                        CLAY_TEXT(CLAY_STRING(", y: "), infoTextConfig);
-                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.y), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING("{ left: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.left), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", right: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.right), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", top: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.top), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", bottom: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.bottom), infoTextConfig);
                         CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
                     }
                     // .childGap
@@ -3348,7 +3405,7 @@ void Clay__RenderDebugView() {
                     switch (elementConfig->type) {
                         case CLAY__ELEMENT_CONFIG_TYPE_RECTANGLE: {
                             Clay_RectangleElementConfig *rectangleConfig = elementConfig->config.rectangleElementConfig;
-                            CLAY(CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .color
                                 CLAY_TEXT(CLAY_STRING("Color"), infoTitleConfig);
                                 Clay__RenderDebugViewColor(rectangleConfig->color, infoTextConfig);
@@ -3360,7 +3417,7 @@ void Clay__RenderDebugView() {
                         }
                         case CLAY__ELEMENT_CONFIG_TYPE_TEXT: {
                             Clay_TextElementConfig *textConfig = elementConfig->config.textElementConfig;
-                            CLAY(CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .fontSize
                                 CLAY_TEXT(CLAY_STRING("Font Size"), infoTitleConfig);
                                 CLAY_TEXT(Clay__IntToString(textConfig->fontSize), infoTextConfig);
@@ -3390,7 +3447,7 @@ void Clay__RenderDebugView() {
                         }
                         case CLAY__ELEMENT_CONFIG_TYPE_IMAGE: {
                             Clay_ImageElementConfig *imageConfig = elementConfig->config.imageElementConfig;
-                            CLAY(CLAY_ID("Clay__DebugViewElementInfoImageBody"), CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_ID("Clay__DebugViewElementInfoImageBody"), CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .sourceDimensions
                                 CLAY_TEXT(CLAY_STRING("Source Dimensions"), infoTitleConfig);
                                 CLAY(CLAY_ID("Clay__DebugViewElementInfoImageDimensions")) {
@@ -3402,13 +3459,13 @@ void Clay__RenderDebugView() {
                                 }
                                 // Image Preview
                                 CLAY_TEXT(CLAY_STRING("Preview"), infoTitleConfig);
-                                CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0, imageConfig->sourceDimensions.width), {0} }}), Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .imageElementConfig = imageConfig }, CLAY__ELEMENT_CONFIG_TYPE_IMAGE)) {}
+                                CLAY(CLAY_LAYOUT({ .sizing = { CLAY_SIZING_GROW(0, imageConfig->sourceDimensions.width) }}), Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .imageElementConfig = imageConfig }, CLAY__ELEMENT_CONFIG_TYPE_IMAGE)) {}
                             }
                             break;
                         }
                         case CLAY__ELEMENT_CONFIG_TYPE_SCROLL_CONTAINER: {
                             Clay_ScrollElementConfig *scrollConfig = elementConfig->config.scrollElementConfig;
-                            CLAY(CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .vertical
                                 CLAY_TEXT(CLAY_STRING("Vertical"), infoTitleConfig);
                                 CLAY_TEXT(scrollConfig->vertical ? CLAY_STRING("true") : CLAY_STRING("false") , infoTextConfig);
@@ -3420,7 +3477,7 @@ void Clay__RenderDebugView() {
                         }
                         case CLAY__ELEMENT_CONFIG_TYPE_FLOATING_CONTAINER: {
                             Clay_FloatingElementConfig *floatingConfig = elementConfig->config.floatingElementConfig;
-                            CLAY(CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .offset
                                 CLAY_TEXT(CLAY_STRING("Offset"), infoTitleConfig);
                                 CLAY(CLAY_LAYOUT(CLAY__DEFAULT_STRUCT)) {
@@ -3451,7 +3508,7 @@ void Clay__RenderDebugView() {
                         }
                         case CLAY__ELEMENT_CONFIG_TYPE_BORDER_CONTAINER: {
                             Clay_BorderElementConfig *borderConfig = elementConfig->config.borderElementConfig;
-                            CLAY(CLAY_ID("Clay__DebugViewElementInfoBorderBody"), CLAY_LAYOUT({ .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 8}, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
+                            CLAY(CLAY_ID("Clay__DebugViewElementInfoBorderBody"), CLAY_LAYOUT({ .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM })) {
                                 // .left
                                 CLAY_TEXT(CLAY_STRING("Left Border"), infoTitleConfig);
                                 Clay__RenderDebugViewBorder(1, borderConfig->left, infoTextConfig);
@@ -3481,14 +3538,14 @@ void Clay__RenderDebugView() {
         } else {
             CLAY(CLAY_ID("Clay__DebugViewWarningsScrollPane"), CLAY_LAYOUT({ .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(300)}, .childGap = 6, .layoutDirection = CLAY_TOP_TO_BOTTOM }), CLAY_SCROLL({ .horizontal = true, .vertical = true }), CLAY_RECTANGLE({ .color = CLAY__DEBUGVIEW_COLOR_2 })) {
                 Clay_TextElementConfig *warningConfig = CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE });
-                CLAY(CLAY_ID("Clay__DebugViewWarningItemHeader"), CLAY_LAYOUT({ .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 0}, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
+                CLAY(CLAY_ID("Clay__DebugViewWarningItemHeader"), CLAY_LAYOUT({ .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING}, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
                     CLAY_TEXT(CLAY_STRING("Warnings"), warningConfig);
                 }
                 CLAY(CLAY_ID("Clay__DebugViewWarningsTopBorder"), CLAY_LAYOUT({ .sizing = { .width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(1)} }), CLAY_RECTANGLE({ .color = {200, 200, 200, 255} })) {}
                 int32_t previousWarningsLength = context->warnings.length;
                 for (int32_t i = 0; i < previousWarningsLength; i++) {
                     Clay__Warning warning = context->warnings.internalArray[i];
-                    CLAY(CLAY_IDI("Clay__DebugViewWarningItem", i), CLAY_LAYOUT({ .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, 0}, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
+                    CLAY(CLAY_IDI("Clay__DebugViewWarningItem", i), CLAY_LAYOUT({ .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING}, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} })) {
                         CLAY_TEXT(warning.baseMessage, warningConfig);
                         if (warning.dynamicMessage.length > 0) {
                             CLAY_TEXT(warning.dynamicMessage, warningConfig);
@@ -3586,7 +3643,7 @@ uint32_t Clay_MinMemorySize(void) {
         .maxMeasureTextCacheWordCount = Clay__defaultMaxMeasureTextWordCacheCount,
         .internalArena = {
             .capacity = SIZE_MAX,
-            .memory = (char*)&fakeContext,
+            .memory = NULL,
         }
     };
     Clay_Context* currentContext = Clay_GetCurrentContext();
@@ -3956,6 +4013,19 @@ Clay_ScrollContainerData Clay_GetScrollContainerData(Clay_ElementId id) {
     return CLAY__INIT(Clay_ScrollContainerData) CLAY__DEFAULT_STRUCT;
 }
 
+CLAY_WASM_EXPORT("Clay_GetElementData")
+Clay_ElementData Clay_GetElementData(Clay_ElementId id){
+    Clay_LayoutElementHashMapItem * item = Clay__GetHashMapItem(id.id);
+    if(item == &CLAY__LAYOUT_ELEMENT_HASH_MAP_ITEM_DEFAULT) {
+        return CLAY__INIT(Clay_ElementData) CLAY__DEFAULT_STRUCT;
+    }
+
+    return CLAY__INIT(Clay_ElementData){
+        .boundingBox = item->boundingBox,
+        .found = true
+    };
+}
+
 CLAY_WASM_EXPORT("Clay_SetDebugModeEnabled")
 void Clay_SetDebugModeEnabled(bool enabled) {
     Clay_Context* context = Clay_GetCurrentContext();
@@ -4010,6 +4080,21 @@ void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount) 
     } else {
         Clay__defaultMaxMeasureTextWordCacheCount = maxMeasureTextCacheWordCount; // TODO: Fix this
     }
+}
+
+CLAY_WASM_EXPORT("Clay_ResetMeasureTextCache")
+void Clay_ResetMeasureTextCache(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->measureTextHashMapInternal.length = 0;
+    context->measureTextHashMapInternalFreeList.length = 0;
+    context->measureTextHashMap.length = 0;
+    context->measuredWords.length = 0;
+    context->measuredWordsFreeList.length = 0;
+    
+    for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
+        context->measureTextHashMap.internalArray[i] = 0;
+    }
+    context->measureTextHashMapInternal.length = 1; // Reserve the 0 value to mean "no next element"
 }
 
 #endif // CLAY_IMPLEMENTATION

--- a/src/bindings/bindings.rs
+++ b/src/bindings/bindings.rs
@@ -1090,15 +1090,20 @@ const _: () = {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_Padding {
-    pub x: u16,
-    pub y: u16,
+    pub left: u16,
+    pub right: u16,
+    pub top: u16,
+    pub bottom: u16,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_Padding"][::core::mem::size_of::<Clay_Padding>() - 4usize];
+    ["Size of Clay_Padding"][::core::mem::size_of::<Clay_Padding>() - 8usize];
     ["Alignment of Clay_Padding"][::core::mem::align_of::<Clay_Padding>() - 2usize];
-    ["Offset of field: Clay_Padding::x"][::core::mem::offset_of!(Clay_Padding, x) - 0usize];
-    ["Offset of field: Clay_Padding::y"][::core::mem::offset_of!(Clay_Padding, y) - 2usize];
+    ["Offset of field: Clay_Padding::left"][::core::mem::offset_of!(Clay_Padding, left) - 0usize];
+    ["Offset of field: Clay_Padding::right"][::core::mem::offset_of!(Clay_Padding, right) - 2usize];
+    ["Offset of field: Clay_Padding::top"][::core::mem::offset_of!(Clay_Padding, top) - 4usize];
+    ["Offset of field: Clay_Padding::bottom"]
+        [::core::mem::offset_of!(Clay_Padding, bottom) - 6usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1108,7 +1113,8 @@ pub struct Clay__AlignClay_Padding {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay__AlignClay_Padding"][::core::mem::size_of::<Clay__AlignClay_Padding>() - 6usize];
+    ["Size of Clay__AlignClay_Padding"]
+        [::core::mem::size_of::<Clay__AlignClay_Padding>() - 10usize];
     ["Alignment of Clay__AlignClay_Padding"]
         [::core::mem::align_of::<Clay__AlignClay_Padding>() - 2usize];
     ["Offset of field: Clay__AlignClay_Padding::c"]
@@ -1124,7 +1130,7 @@ pub struct Clay__Clay_PaddingWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_PaddingWrapper"]
-        [::core::mem::size_of::<Clay__Clay_PaddingWrapper>() - 4usize];
+        [::core::mem::size_of::<Clay__Clay_PaddingWrapper>() - 8usize];
     ["Alignment of Clay__Clay_PaddingWrapper"]
         [::core::mem::align_of::<Clay__Clay_PaddingWrapper>() - 2usize];
     ["Offset of field: Clay__Clay_PaddingWrapper::wrapped"]
@@ -1141,18 +1147,18 @@ pub struct Clay_LayoutConfig {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_LayoutConfig"][::core::mem::size_of::<Clay_LayoutConfig>() - 36usize];
+    ["Size of Clay_LayoutConfig"][::core::mem::size_of::<Clay_LayoutConfig>() - 40usize];
     ["Alignment of Clay_LayoutConfig"][::core::mem::align_of::<Clay_LayoutConfig>() - 4usize];
     ["Offset of field: Clay_LayoutConfig::sizing"]
         [::core::mem::offset_of!(Clay_LayoutConfig, sizing) - 0usize];
     ["Offset of field: Clay_LayoutConfig::padding"]
         [::core::mem::offset_of!(Clay_LayoutConfig, padding) - 24usize];
     ["Offset of field: Clay_LayoutConfig::childGap"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, childGap) - 28usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, childGap) - 32usize];
     ["Offset of field: Clay_LayoutConfig::childAlignment"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, childAlignment) - 30usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, childAlignment) - 34usize];
     ["Offset of field: Clay_LayoutConfig::layoutDirection"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, layoutDirection) - 32usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, layoutDirection) - 36usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1163,7 +1169,7 @@ pub struct Clay__AlignClay_LayoutConfig {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__AlignClay_LayoutConfig"]
-        [::core::mem::size_of::<Clay__AlignClay_LayoutConfig>() - 40usize];
+        [::core::mem::size_of::<Clay__AlignClay_LayoutConfig>() - 44usize];
     ["Alignment of Clay__AlignClay_LayoutConfig"]
         [::core::mem::align_of::<Clay__AlignClay_LayoutConfig>() - 4usize];
     ["Offset of field: Clay__AlignClay_LayoutConfig::c"]
@@ -1179,7 +1185,7 @@ pub struct Clay__Clay_LayoutConfigWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_LayoutConfigWrapper"]
-        [::core::mem::size_of::<Clay__Clay_LayoutConfigWrapper>() - 36usize];
+        [::core::mem::size_of::<Clay__Clay_LayoutConfigWrapper>() - 40usize];
     ["Alignment of Clay__Clay_LayoutConfigWrapper"]
         [::core::mem::align_of::<Clay__Clay_LayoutConfigWrapper>() - 4usize];
     ["Offset of field: Clay__Clay_LayoutConfigWrapper::wrapped"]
@@ -1932,6 +1938,52 @@ const _: () = {
     ["Offset of field: Clay__Clay_ScrollContainerDataWrapper::wrapped"]
         [::core::mem::offset_of!(Clay__Clay_ScrollContainerDataWrapper, wrapped) - 0usize];
 };
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay_ElementData {
+    pub boundingBox: Clay_BoundingBox,
+    pub found: bool,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay_ElementData"][::core::mem::size_of::<Clay_ElementData>() - 20usize];
+    ["Alignment of Clay_ElementData"][::core::mem::align_of::<Clay_ElementData>() - 4usize];
+    ["Offset of field: Clay_ElementData::boundingBox"]
+        [::core::mem::offset_of!(Clay_ElementData, boundingBox) - 0usize];
+    ["Offset of field: Clay_ElementData::found"]
+        [::core::mem::offset_of!(Clay_ElementData, found) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__AlignClay_ElementData {
+    pub c: ::core::ffi::c_char,
+    pub x: Clay_ElementData,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__AlignClay_ElementData"]
+        [::core::mem::size_of::<Clay__AlignClay_ElementData>() - 24usize];
+    ["Alignment of Clay__AlignClay_ElementData"]
+        [::core::mem::align_of::<Clay__AlignClay_ElementData>() - 4usize];
+    ["Offset of field: Clay__AlignClay_ElementData::c"]
+        [::core::mem::offset_of!(Clay__AlignClay_ElementData, c) - 0usize];
+    ["Offset of field: Clay__AlignClay_ElementData::x"]
+        [::core::mem::offset_of!(Clay__AlignClay_ElementData, x) - 4usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__Clay_ElementDataWrapper {
+    pub wrapped: Clay_ElementData,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__Clay_ElementDataWrapper"]
+        [::core::mem::size_of::<Clay__Clay_ElementDataWrapper>() - 20usize];
+    ["Alignment of Clay__Clay_ElementDataWrapper"]
+        [::core::mem::align_of::<Clay__Clay_ElementDataWrapper>() - 4usize];
+    ["Offset of field: Clay__Clay_ElementDataWrapper::wrapped"]
+        [::core::mem::offset_of!(Clay__Clay_ElementDataWrapper, wrapped) - 0usize];
+};
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_NONE: Clay_RenderCommandType = 0;
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_RECTANGLE: Clay_RenderCommandType = 1;
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_BORDER: Clay_RenderCommandType = 2;
@@ -2347,6 +2399,9 @@ unsafe extern "C" {
     pub fn Clay_GetElementIdWithIndex(idString: Clay_String, index: u32) -> Clay_ElementId;
 }
 unsafe extern "C" {
+    pub fn Clay_GetElementData(id: Clay_ElementId) -> Clay_ElementData;
+}
+unsafe extern "C" {
     pub fn Clay_Hovered() -> bool;
 }
 unsafe extern "C" {
@@ -2410,6 +2465,9 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn Clay_SetMaxMeasureTextCacheWordCount(maxMeasureTextCacheWordCount: i32);
+}
+unsafe extern "C" {
+    pub fn Clay_ResetMeasureTextCache();
 }
 unsafe extern "C" {
     pub fn Clay__OpenElement();

--- a/src/bindings/bindings_debug.rs
+++ b/src/bindings/bindings_debug.rs
@@ -1090,15 +1090,20 @@ const _: () = {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_Padding {
-    pub x: u16,
-    pub y: u16,
+    pub left: u16,
+    pub right: u16,
+    pub top: u16,
+    pub bottom: u16,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_Padding"][::core::mem::size_of::<Clay_Padding>() - 4usize];
+    ["Size of Clay_Padding"][::core::mem::size_of::<Clay_Padding>() - 8usize];
     ["Alignment of Clay_Padding"][::core::mem::align_of::<Clay_Padding>() - 2usize];
-    ["Offset of field: Clay_Padding::x"][::core::mem::offset_of!(Clay_Padding, x) - 0usize];
-    ["Offset of field: Clay_Padding::y"][::core::mem::offset_of!(Clay_Padding, y) - 2usize];
+    ["Offset of field: Clay_Padding::left"][::core::mem::offset_of!(Clay_Padding, left) - 0usize];
+    ["Offset of field: Clay_Padding::right"][::core::mem::offset_of!(Clay_Padding, right) - 2usize];
+    ["Offset of field: Clay_Padding::top"][::core::mem::offset_of!(Clay_Padding, top) - 4usize];
+    ["Offset of field: Clay_Padding::bottom"]
+        [::core::mem::offset_of!(Clay_Padding, bottom) - 6usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1108,7 +1113,8 @@ pub struct Clay__AlignClay_Padding {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay__AlignClay_Padding"][::core::mem::size_of::<Clay__AlignClay_Padding>() - 6usize];
+    ["Size of Clay__AlignClay_Padding"]
+        [::core::mem::size_of::<Clay__AlignClay_Padding>() - 10usize];
     ["Alignment of Clay__AlignClay_Padding"]
         [::core::mem::align_of::<Clay__AlignClay_Padding>() - 2usize];
     ["Offset of field: Clay__AlignClay_Padding::c"]
@@ -1124,7 +1130,7 @@ pub struct Clay__Clay_PaddingWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_PaddingWrapper"]
-        [::core::mem::size_of::<Clay__Clay_PaddingWrapper>() - 4usize];
+        [::core::mem::size_of::<Clay__Clay_PaddingWrapper>() - 8usize];
     ["Alignment of Clay__Clay_PaddingWrapper"]
         [::core::mem::align_of::<Clay__Clay_PaddingWrapper>() - 2usize];
     ["Offset of field: Clay__Clay_PaddingWrapper::wrapped"]
@@ -1141,18 +1147,18 @@ pub struct Clay_LayoutConfig {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_LayoutConfig"][::core::mem::size_of::<Clay_LayoutConfig>() - 36usize];
+    ["Size of Clay_LayoutConfig"][::core::mem::size_of::<Clay_LayoutConfig>() - 40usize];
     ["Alignment of Clay_LayoutConfig"][::core::mem::align_of::<Clay_LayoutConfig>() - 4usize];
     ["Offset of field: Clay_LayoutConfig::sizing"]
         [::core::mem::offset_of!(Clay_LayoutConfig, sizing) - 0usize];
     ["Offset of field: Clay_LayoutConfig::padding"]
         [::core::mem::offset_of!(Clay_LayoutConfig, padding) - 24usize];
     ["Offset of field: Clay_LayoutConfig::childGap"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, childGap) - 28usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, childGap) - 32usize];
     ["Offset of field: Clay_LayoutConfig::childAlignment"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, childAlignment) - 30usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, childAlignment) - 34usize];
     ["Offset of field: Clay_LayoutConfig::layoutDirection"]
-        [::core::mem::offset_of!(Clay_LayoutConfig, layoutDirection) - 32usize];
+        [::core::mem::offset_of!(Clay_LayoutConfig, layoutDirection) - 36usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1163,7 +1169,7 @@ pub struct Clay__AlignClay_LayoutConfig {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__AlignClay_LayoutConfig"]
-        [::core::mem::size_of::<Clay__AlignClay_LayoutConfig>() - 40usize];
+        [::core::mem::size_of::<Clay__AlignClay_LayoutConfig>() - 44usize];
     ["Alignment of Clay__AlignClay_LayoutConfig"]
         [::core::mem::align_of::<Clay__AlignClay_LayoutConfig>() - 4usize];
     ["Offset of field: Clay__AlignClay_LayoutConfig::c"]
@@ -1179,7 +1185,7 @@ pub struct Clay__Clay_LayoutConfigWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_LayoutConfigWrapper"]
-        [::core::mem::size_of::<Clay__Clay_LayoutConfigWrapper>() - 36usize];
+        [::core::mem::size_of::<Clay__Clay_LayoutConfigWrapper>() - 40usize];
     ["Alignment of Clay__Clay_LayoutConfigWrapper"]
         [::core::mem::align_of::<Clay__Clay_LayoutConfigWrapper>() - 4usize];
     ["Offset of field: Clay__Clay_LayoutConfigWrapper::wrapped"]
@@ -1932,6 +1938,52 @@ const _: () = {
     ["Offset of field: Clay__Clay_ScrollContainerDataWrapper::wrapped"]
         [::core::mem::offset_of!(Clay__Clay_ScrollContainerDataWrapper, wrapped) - 0usize];
 };
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay_ElementData {
+    pub boundingBox: Clay_BoundingBox,
+    pub found: bool,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay_ElementData"][::core::mem::size_of::<Clay_ElementData>() - 20usize];
+    ["Alignment of Clay_ElementData"][::core::mem::align_of::<Clay_ElementData>() - 4usize];
+    ["Offset of field: Clay_ElementData::boundingBox"]
+        [::core::mem::offset_of!(Clay_ElementData, boundingBox) - 0usize];
+    ["Offset of field: Clay_ElementData::found"]
+        [::core::mem::offset_of!(Clay_ElementData, found) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__AlignClay_ElementData {
+    pub c: ::core::ffi::c_char,
+    pub x: Clay_ElementData,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__AlignClay_ElementData"]
+        [::core::mem::size_of::<Clay__AlignClay_ElementData>() - 24usize];
+    ["Alignment of Clay__AlignClay_ElementData"]
+        [::core::mem::align_of::<Clay__AlignClay_ElementData>() - 4usize];
+    ["Offset of field: Clay__AlignClay_ElementData::c"]
+        [::core::mem::offset_of!(Clay__AlignClay_ElementData, c) - 0usize];
+    ["Offset of field: Clay__AlignClay_ElementData::x"]
+        [::core::mem::offset_of!(Clay__AlignClay_ElementData, x) - 4usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__Clay_ElementDataWrapper {
+    pub wrapped: Clay_ElementData,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__Clay_ElementDataWrapper"]
+        [::core::mem::size_of::<Clay__Clay_ElementDataWrapper>() - 20usize];
+    ["Alignment of Clay__Clay_ElementDataWrapper"]
+        [::core::mem::align_of::<Clay__Clay_ElementDataWrapper>() - 4usize];
+    ["Offset of field: Clay__Clay_ElementDataWrapper::wrapped"]
+        [::core::mem::offset_of!(Clay__Clay_ElementDataWrapper, wrapped) - 0usize];
+};
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_NONE: Clay_RenderCommandType = 0;
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_RECTANGLE: Clay_RenderCommandType = 1;
 pub const Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_BORDER: Clay_RenderCommandType = 2;
@@ -2347,6 +2399,9 @@ unsafe extern "C" {
     pub fn Clay_GetElementIdWithIndex(idString: Clay_String, index: u32) -> Clay_ElementId;
 }
 unsafe extern "C" {
+    pub fn Clay_GetElementData(id: Clay_ElementId) -> Clay_ElementData;
+}
+unsafe extern "C" {
     pub fn Clay_Hovered() -> bool;
 }
 unsafe extern "C" {
@@ -2410,6 +2465,9 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn Clay_SetMaxMeasureTextCacheWordCount(maxMeasureTextCacheWordCount: i32);
+}
+unsafe extern "C" {
+    pub fn Clay_ResetMeasureTextCache();
 }
 unsafe extern "C" {
     pub fn Clay__OpenElement();

--- a/src/layout/padding.rs
+++ b/src/layout/padding.rs
@@ -10,7 +10,12 @@ pub struct Padding {
 
 impl Padding {
     pub fn new_rect(left: u16, right: u16, top: u16, bottom: u16) -> Self {
-        Self { left, right, top, bottom }
+        Self {
+            left,
+            right,
+            top,
+            bottom,
+        }
     }
 
     pub fn all(value: u16) -> Self {

--- a/src/layout/padding.rs
+++ b/src/layout/padding.rs
@@ -1,14 +1,20 @@
 use crate::bindings::*;
 
+/// Represents padding with values for left, right, top, and bottom.
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Padding {
+    /// Padding value for the left side.
     pub left: u16,
+    /// Padding value for the right side.
     pub right: u16,
+    /// Padding value for the top side.
     pub top: u16,
+    /// Padding value for the bottom side.
     pub bottom: u16,
 }
 
 impl Padding {
+    /// Creates a new `Padding` instance with specific values for all sides.
     pub fn new_rect(left: u16, right: u16, top: u16, bottom: u16) -> Self {
         Self {
             left,
@@ -18,42 +24,51 @@ impl Padding {
         }
     }
 
+    /// Creates a new `Padding` instance with the same value for all sides.
     pub fn all(value: u16) -> Self {
         Self::new_rect(value, value, value, value)
     }
 
+    /// Creates a new `Padding` instance with the same value for left and right sides.
     pub fn horizontal(value: u16) -> Self {
         Self::new_rect(value, value, 0, 0)
     }
 
+    /// Creates a new `Padding` instance with the same value for top and bottom sides.
     pub fn vertical(value: u16) -> Self {
         Self::new_rect(0, 0, value, value)
     }
 
+    /// Creates a new `Padding` instance with default values (all zero).
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the padding value for the left side.
     pub fn left(&mut self, value: u16) -> &mut Self {
         self.left = value;
         self
     }
 
+    /// Sets the padding value for the right side.
     pub fn right(&mut self, value: u16) -> &mut Self {
         self.right = value;
         self
     }
 
+    /// Sets the padding value for the top side.
     pub fn top(&mut self, value: u16) -> &mut Self {
         self.top = value;
         self
     }
 
+    /// Sets the padding value for the bottom side.
     pub fn bottom(&mut self, value: u16) -> &mut Self {
         self.bottom = value;
         self
     }
 
+    /// Finalizes the modifications and returns the updated `Padding` instance.
     pub fn end(&mut self) -> Self {
         *self
     }

--- a/src/layout/padding.rs
+++ b/src/layout/padding.rs
@@ -2,35 +2,81 @@ use crate::bindings::*;
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Padding {
-    pub x: u16,
-    pub y: u16,
+    pub left: u16,
+    pub right: u16,
+    pub top: u16,
+    pub bottom: u16,
 }
 
 impl Padding {
-    pub fn new(x: u16, y: u16) -> Self {
-        Self { x, y }
+    pub fn new_rect(left: u16, right: u16, top: u16, bottom: u16) -> Self {
+        Self { left, right, top, bottom }
+    }
+
+    pub fn all(value: u16) -> Self {
+        Self::new_rect(value, value, value, value)
+    }
+
+    pub fn horizontal(value: u16) -> Self {
+        Self::new_rect(value, value, 0, 0)
+    }
+
+    pub fn vertical(value: u16) -> Self {
+        Self::new_rect(0, 0, value, value)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn left(&mut self, value: u16) -> &mut Self {
+        self.left = value;
+        self
+    }
+
+    pub fn right(&mut self, value: u16) -> &mut Self {
+        self.right = value;
+        self
+    }
+
+    pub fn top(&mut self, value: u16) -> &mut Self {
+        self.top = value;
+        self
+    }
+
+    pub fn bottom(&mut self, value: u16) -> &mut Self {
+        self.bottom = value;
+        self
+    }
+
+    pub fn end(&mut self) -> Self {
+        *self
     }
 }
 
 impl From<Clay_Padding> for Padding {
     fn from(value: Clay_Padding) -> Self {
         Self {
-            x: value.x,
-            y: value.y,
+            left: value.left,
+            right: value.right,
+            top: value.top,
+            bottom: value.bottom,
         }
     }
 }
 impl From<Padding> for Clay_Padding {
     fn from(value: Padding) -> Self {
         Self {
-            x: value.x,
-            y: value.y,
+            left: value.left,
+            right: value.right,
+            top: value.top,
+            bottom: value.bottom,
         }
     }
 }
 
-impl From<(u16, u16)> for Padding {
-    fn from(other: (u16, u16)) -> Self {
-        Self::new(other.0, other.1)
+impl From<(u16, u16, u16, u16)> for Padding {
+    fn from(other: (u16, u16, u16, u16)) -> Self {
+        Self::new_rect(other.0, other.1, other.2, other.3)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod mem;
 
 use elements::{text::TextElementConfig, ElementConfigType};
 use errors::Error;
-use math::{Dimensions, Vector2};
+use math::{Dimensions, Vector2, BoundingBox};
 use render_commands::RenderCommand;
 
 use crate::bindings::*;
@@ -196,6 +196,20 @@ impl<'a> Clay<'a> {
         unsafe { Clay_PointerOver(cfg.id) }
     }
 
+    fn get_element_data(id: TypedConfig) -> Clay_ElementData {
+        unsafe { Clay_GetElementData(id.id).into() }
+    }
+
+    pub fn get_bounding_box(&self, id: TypedConfig) -> Option<BoundingBox> {
+        let element_data = Self::get_element_data(id);
+
+        if element_data.found {
+            Some(element_data.boundingBox.into())
+        } else {
+            None
+        }
+    }
+
     pub fn begin(&self) {
         unsafe { Clay_BeginLayout() };
     }
@@ -299,7 +313,7 @@ mod tests {
                 Layout::new()
                     .width(Sizing::Fixed(100.0))
                     .height(Sizing::Fixed(100.0))
-                    .padding(Padding::new(10, 10))
+                    .padding(Padding::all(10))
                     .end(),
                 Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
                 // FloatingContainer::new().end(Id::new("tegfddgftds"))
@@ -311,7 +325,7 @@ mod tests {
                         Layout::new()
                             .width(Sizing::Fixed(100.0))
                             .height(Sizing::Fixed(100.0))
-                            .padding(Padding::new(10, 10))
+                            .padding(Padding::all(10))
                             .end(),
                         Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
                     ],
@@ -329,7 +343,7 @@ mod tests {
         clay.with(
             [
                 Id::new_index("Border_container", 1),
-                Layout::new().padding(Padding::new(16, 16)).end(),
+                Layout::new().padding(Padding::all(16)).end(),
                 BorderContainer::new()
                     .all_directions(2, Color::rgb(255., 255., 0.))
                     .corner_radius(CornerRadius::All(25.))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl<'a> Clay<'a> {
     }
 
     fn get_element_data(id: TypedConfig) -> Clay_ElementData {
-        unsafe { Clay_GetElementData(id.id).into() }
+        unsafe { Clay_GetElementData(id.id) }
     }
 
     pub fn get_bounding_box(&self, id: TypedConfig) -> Option<BoundingBox> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod mem;
 
 use elements::{text::TextElementConfig, ElementConfigType};
 use errors::Error;
-use math::{Dimensions, Vector2, BoundingBox};
+use math::{BoundingBox, Dimensions, Vector2};
 use render_commands::RenderCommand;
 
 use crate::bindings::*;


### PR DESCRIPTION
* Updated to latest Clay
* New Clay changes the padding so it's now `left, right, top, bottom` So changed the `Padding` struct to allow for easier access of setting this data
* New Clay adds access to the `BoundingBox` based on ID so added access to that. The Rust version uses `Option` here instead of a struct + bool