### PR TITLE
Support measure text with user data

### DIFF
--- a/src/bindings/bindings.rs
+++ b/src/bindings/bindings.rs
@@ -365,6 +365,55 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct Clay_StringSlice {
+    pub length: i32,
+    pub chars: *const ::core::ffi::c_char,
+    pub baseChars: *const ::core::ffi::c_char,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay_StringSlice"][::core::mem::size_of::<Clay_StringSlice>() - 24usize];
+    ["Alignment of Clay_StringSlice"][::core::mem::align_of::<Clay_StringSlice>() - 8usize];
+    ["Offset of field: Clay_StringSlice::length"]
+        [::core::mem::offset_of!(Clay_StringSlice, length) - 0usize];
+    ["Offset of field: Clay_StringSlice::chars"]
+        [::core::mem::offset_of!(Clay_StringSlice, chars) - 8usize];
+    ["Offset of field: Clay_StringSlice::baseChars"]
+        [::core::mem::offset_of!(Clay_StringSlice, baseChars) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__AlignClay_StringSlice {
+    pub c: ::core::ffi::c_char,
+    pub x: Clay_StringSlice,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__AlignClay_StringSlice"]
+        [::core::mem::size_of::<Clay__AlignClay_StringSlice>() - 32usize];
+    ["Alignment of Clay__AlignClay_StringSlice"]
+        [::core::mem::align_of::<Clay__AlignClay_StringSlice>() - 8usize];
+    ["Offset of field: Clay__AlignClay_StringSlice::c"]
+        [::core::mem::offset_of!(Clay__AlignClay_StringSlice, c) - 0usize];
+    ["Offset of field: Clay__AlignClay_StringSlice::x"]
+        [::core::mem::offset_of!(Clay__AlignClay_StringSlice, x) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__Clay_StringSliceWrapper {
+    pub wrapped: Clay_StringSlice,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__Clay_StringSliceWrapper"]
+        [::core::mem::size_of::<Clay__Clay_StringSliceWrapper>() - 24usize];
+    ["Alignment of Clay__Clay_StringSliceWrapper"]
+        [::core::mem::align_of::<Clay__Clay_StringSliceWrapper>() - 8usize];
+    ["Offset of field: Clay__Clay_StringSliceWrapper::wrapped"]
+        [::core::mem::offset_of!(Clay__Clay_StringSliceWrapper, wrapped) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Clay_Context {
     _unused: [u8; 0],
 }
@@ -2426,17 +2475,20 @@ unsafe extern "C" {
     pub fn Clay_SetMeasureTextFunction(
         measureTextFunction: ::core::option::Option<
             unsafe extern "C" fn(
-                text: *mut Clay_String,
+                text: Clay_StringSlice,
                 config: *mut Clay_TextElementConfig,
+                userData: usize,
             ) -> Clay_Dimensions,
         >,
+        userData: usize,
     );
 }
 unsafe extern "C" {
     pub fn Clay_SetQueryScrollOffsetFunction(
         queryScrollOffsetFunction: ::core::option::Option<
-            unsafe extern "C" fn(elementId: u32) -> Clay_Vector2,
+            unsafe extern "C" fn(elementId: u32, userData: usize) -> Clay_Vector2,
         >,
+        userData: usize,
     );
 }
 unsafe extern "C" {

--- a/src/bindings/bindings_debug.rs
+++ b/src/bindings/bindings_debug.rs
@@ -365,6 +365,55 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct Clay_StringSlice {
+    pub length: i32,
+    pub chars: *const ::core::ffi::c_char,
+    pub baseChars: *const ::core::ffi::c_char,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay_StringSlice"][::core::mem::size_of::<Clay_StringSlice>() - 24usize];
+    ["Alignment of Clay_StringSlice"][::core::mem::align_of::<Clay_StringSlice>() - 8usize];
+    ["Offset of field: Clay_StringSlice::length"]
+        [::core::mem::offset_of!(Clay_StringSlice, length) - 0usize];
+    ["Offset of field: Clay_StringSlice::chars"]
+        [::core::mem::offset_of!(Clay_StringSlice, chars) - 8usize];
+    ["Offset of field: Clay_StringSlice::baseChars"]
+        [::core::mem::offset_of!(Clay_StringSlice, baseChars) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__AlignClay_StringSlice {
+    pub c: ::core::ffi::c_char,
+    pub x: Clay_StringSlice,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__AlignClay_StringSlice"]
+        [::core::mem::size_of::<Clay__AlignClay_StringSlice>() - 32usize];
+    ["Alignment of Clay__AlignClay_StringSlice"]
+        [::core::mem::align_of::<Clay__AlignClay_StringSlice>() - 8usize];
+    ["Offset of field: Clay__AlignClay_StringSlice::c"]
+        [::core::mem::offset_of!(Clay__AlignClay_StringSlice, c) - 0usize];
+    ["Offset of field: Clay__AlignClay_StringSlice::x"]
+        [::core::mem::offset_of!(Clay__AlignClay_StringSlice, x) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Clay__Clay_StringSliceWrapper {
+    pub wrapped: Clay_StringSlice,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Clay__Clay_StringSliceWrapper"]
+        [::core::mem::size_of::<Clay__Clay_StringSliceWrapper>() - 24usize];
+    ["Alignment of Clay__Clay_StringSliceWrapper"]
+        [::core::mem::align_of::<Clay__Clay_StringSliceWrapper>() - 8usize];
+    ["Offset of field: Clay__Clay_StringSliceWrapper::wrapped"]
+        [::core::mem::offset_of!(Clay__Clay_StringSliceWrapper, wrapped) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Clay_Context {
     _unused: [u8; 0],
 }
@@ -2426,17 +2475,20 @@ unsafe extern "C" {
     pub fn Clay_SetMeasureTextFunction(
         measureTextFunction: ::core::option::Option<
             unsafe extern "C" fn(
-                text: *mut Clay_String,
+                text: Clay_StringSlice,
                 config: *mut Clay_TextElementConfig,
+                userData: usize,
             ) -> Clay_Dimensions,
         >,
+        userData: usize,
     );
 }
 unsafe extern "C" {
     pub fn Clay_SetQueryScrollOffsetFunction(
         queryScrollOffsetFunction: ::core::option::Option<
-            unsafe extern "C" fn(elementId: u32) -> Clay_Vector2,
+            unsafe extern "C" fn(elementId: u32, userData: usize) -> Clay_Vector2,
         >,
+        userData: usize,
     );
 }
 unsafe extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,40 +430,23 @@ mod tests {
                     .height(Sizing::Fixed(100.0))
                     .padding(Padding::all(10))
                     .end(),
-
-                Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
-                // FloatingContainer::new().end(Id::new("tegfddgftds"))
-            ],
-            |clay| {
-                clay.with(
-                    [
-                        Id::new("rect_under_rect"),
-                        Layout::new()
-                            .width(Sizing::Fixed(100.0))
-                            .height(Sizing::Fixed(100.0))
-                            .padding(Padding::all(10))
-                            .end(),
-                        Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
-                    ],
-                    |clay| {
-                        clay.text(
-                            "test",
-                            Text::new()
-                                .color(Color::rgb(255., 255., 255.))
-                                .font_size(24)
-                                .end(),
-                        );
+                Rectangle::new().color(Color::rgb(255., 255., 255.)).end()], |clay| 
+            {
+                clay.with(Some("rect_under_rect"), [
+                    Layout::new()
+                        .width(Sizing::Fixed(100.0))
+                        .height(Sizing::Fixed(100.0))
+                        .padding(Padding::all(10))
+                        .end(),
+                    Rectangle::new().color(Color::rgb(255., 255., 255.)).end()], |clay| 
+                    {
+                        clay.text("test", Text::new()
+                            .color(Color::rgb(255., 255., 255.))
+                            .font_size(24)
+                            .end());
                     },
                 );
-            },
-        );
-        clay.with(
-            [
-                Id::new_index("Border_container", 1),
-                Layout::new().padding(Padding::all(16)).end(),
-                BorderContainer::new()
-                    .all_directions(2, Color::rgb(255., 255., 0.))
-            );
+            });
         });
 
         clay.with_id_index(Some(("Border_container", 1)), [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod render_commands;
 
 mod mem;
 
+use crate::elements::text::Text;
 use elements::{text::TextElementConfig, ElementConfigType};
 use errors::Error;
 use math::{BoundingBox, Dimensions, Vector2};
@@ -27,23 +28,44 @@ pub struct TypedConfig {
     pub config_type: ElementConfigType,
 }
 
-pub type MeasureTextFunction = fn(text: &str, config: TextElementConfig) -> Dimensions;
-
-// Is used to store the current callback for measuring text
-static mut MEASURE_TEXT_HANDLER: Option<MeasureTextFunction> = None;
-
-// Converts the args and calls `MEASURE_TEXT_HANDLER`. Passed to clay with `Clay_SetMeasureTextFunction`
-unsafe extern "C" fn measure_text_handle(
-    str: *mut Clay_String,
+#[cfg(feature = "std")]
+unsafe extern "C" fn measure_text_trampoline_user_data<'a, F, T>(
+    text_slice: Clay_StringSlice,
     config: *mut Clay_TextElementConfig,
-) -> Clay_Dimensions {
-    match MEASURE_TEXT_HANDLER {
-        Some(func) => func((*str.as_ref().unwrap()).into(), config.into()).into(),
-        None => Clay_Dimensions {
-            width: 0.0,
-            height: 0.0,
-        },
-    }
+    user_data: usize,
+) -> Clay_Dimensions
+where
+    F: Fn(&str, &Text, &'a mut T) -> Dimensions + 'a,
+    T: 'a,
+{
+    let text = core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+        text_slice.chars as *const u8,
+        text_slice.length as _,
+    ));
+
+    let closure_and_data: &mut (F, T) = &mut *(user_data as *mut (F, T));
+    let text_config = Text::from(*config);
+    let (callback, data) = closure_and_data;
+    callback(text, &text_config, data).into()
+}
+
+#[cfg(feature = "std")]
+unsafe extern "C" fn measure_text_trampoline<'a, F>(
+    text_slice: Clay_StringSlice,
+    config: *mut Clay_TextElementConfig,
+    user_data: usize,
+) -> Clay_Dimensions
+where
+    F: Fn(&str, &Text) -> Dimensions + 'a,
+{
+    let text = core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+        text_slice.chars as *const u8,
+        text_slice.length as _,
+    ));
+
+    let callback: &mut F = &mut *(user_data as *mut F);
+    let text_config = Text::from(*config);
+    callback(text, &text_config).into()
 }
 
 unsafe extern "C" fn error_handler(error_data: Clay_ErrorData) {
@@ -56,6 +78,7 @@ pub struct DataRef<'a> {
     _phantom: core::marker::PhantomData<&'a ()>,
 }
 
+#[allow(dead_code)]
 pub struct Clay<'a> {
     /// Memory used internally by clay
     #[cfg(feature = "std")]
@@ -67,6 +90,8 @@ pub struct Clay<'a> {
     _memory: *const core::ffi::c_void,
     /// Phantom data to keep the lifetime of the memory
     _phantom: core::marker::PhantomData<&'a ()>,
+    /// Stores the raw pointer to the callback data for later cleanup
+    text_measure_callback: Option<*const core::ffi::c_void>,
 }
 
 impl<'a> Clay<'a> {
@@ -94,6 +119,7 @@ impl<'a> Clay<'a> {
             _memory: memory,
             context,
             _phantom: core::marker::PhantomData,
+            text_measure_callback: None,
         }
     }
 
@@ -124,6 +150,7 @@ impl<'a> Clay<'a> {
             _memory: memory,
             context,
             _phantom: core::marker::PhantomData,
+            text_measure_callback: None,
         }
     }
 
@@ -132,12 +159,50 @@ impl<'a> Clay<'a> {
         unsafe { Clay_MinMemorySize() as usize }
     }
 
-    /// Sets the function used by clay to measure dimensions of strings of `Text` elements
-    pub fn measure_text_function(&self, func: MeasureTextFunction) {
+    /// Set the callback for text measurement with user data
+    #[cfg(feature = "std")]
+    pub fn set_measure_text_function_user_data<F, T>(&mut self, userdata: T, callback: F)
+    where
+        F: Fn(&str, &Text, &'a mut T) -> Dimensions + 'static,
+        T: 'a,
+    {
+        // Box the callback and userdata together
+        let boxed = Box::new((callback, userdata));
+
+        // Get a raw pointer to the boxed data
+        let user_data_ptr = Box::into_raw(boxed) as usize;
+
+        // Register the callback with the external C function
         unsafe {
-            MEASURE_TEXT_HANDLER = Some(func);
-            Clay_SetMeasureTextFunction(Some(measure_text_handle));
+            Clay_SetMeasureTextFunction(
+                Some(measure_text_trampoline_user_data::<F, T>),
+                user_data_ptr,
+            );
         }
+
+        // Store the raw pointer for later cleanup
+        self.text_measure_callback = Some(user_data_ptr as *const core::ffi::c_void);
+    }
+
+    /// Set the callback for text measurement
+    #[cfg(feature = "std")]
+    pub fn set_measure_text_function<F>(&mut self, callback: F)
+    where
+        F: Fn(&str, &Text) -> Dimensions + 'static,
+    {
+        // Box the callback and userdata together
+        let boxed = Box::new(callback);
+
+        // Get a raw pointer to the boxed data
+        let user_data_ptr = Box::into_raw(boxed) as usize;
+
+        // Register the callback with the external C function
+        unsafe {
+            Clay_SetMeasureTextFunction(Some(measure_text_trampoline::<F>), user_data_ptr);
+        }
+
+        // Store the raw pointer for later cleanup
+        self.text_measure_callback = Some(user_data_ptr as *const core::ffi::c_void);
     }
 
     /// Sets the maximum number of element that clay supports
@@ -262,6 +327,17 @@ impl<'a> Clay<'a> {
     }
 }
 
+#[cfg(feature = "std")]
+impl Drop for Clay<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(ptr) = self.text_measure_callback {
+                let _ = Box::from_raw(ptr as *mut (usize, usize));
+            }
+        }
+    }
+}
+
 impl From<&str> for Clay_String {
     fn from(value: &str) -> Self {
         Self {
@@ -301,9 +377,18 @@ mod tests {
 
     #[test]
     fn test_begin() {
-        let clay = Clay::new(Dimensions::new(800.0, 600.0));
+        let mut callback_data = 0u32;
 
-        clay.measure_text_function(|_, _| Dimensions::default());
+        let mut clay = Clay::new(Dimensions::new(800.0, 600.0));
+
+        clay.set_measure_text_function_user_data(&mut callback_data, |text, _config, data| {
+            println!(
+                "set_measure_text_function_user_data {:?} count {:?}",
+                text, data
+            );
+            **data += 1;
+            Dimensions::default()
+        });
 
         clay.begin();
 
@@ -329,14 +414,15 @@ mod tests {
                             .end(),
                         Rectangle::new().color(Color::rgb(255., 255., 255.)).end(),
                     ],
-                    |_clay| {},
-                );
-                clay.text(
-                    "test",
-                    Text::new()
-                        .color(Color::rgb(255., 255., 255.))
-                        .font_size(24)
-                        .end(),
+                    |clay| {
+                        clay.text(
+                            "test",
+                            Text::new()
+                                .color(Color::rgb(255., 255., 255.))
+                                .font_size(24)
+                                .end(),
+                        );
+                    },
                 );
             },
         );


### PR DESCRIPTION
I added user_data pointer to the measure text callback yesterday and here is the added support for the Rust wrapper. I have added so there are two function

```Rust
set_measure_text_function_user_data(&mut m_data, | ... | ... );
set_measure_text_function(| ... | ... );`
```
Example
```Rust
 let mut callback_data = 0u32;

        let mut clay = Clay::new(Dimensions::new(800.0, 600.0));

        clay.set_measure_text_function_user_data(&mut callback_data, |text, _config, data| {
            println!(
                "set_measure_text_function_user_data {:?} count {:?}",
                text, data
            );
            **data += 1;
            Dimensions::default()
        });
```
Also the new set function makes sure that captures works correct (which requires boxing and such) also lifetimes should be correct now as well (if you move the `u32` above to be create after the `Clay` object you will get a compile error) Getting this to work was a bit fiddle, but hopefully it's there now.