### PR TITLE
Make sure Border data can be accessed

### DIFF
--- a/src/elements/containers/border.rs
+++ b/src/elements/containers/border.rs
@@ -7,8 +7,8 @@ use crate::{
 
 #[derive(Debug, Clone, Copy)]
 pub struct Border {
-    width: u32,
-    color: Color,
+    pub width: u32,
+    pub color: Color,
 }
 
 impl Border {


### PR DESCRIPTION
When I started to look into adding border rending I notice that it wasn't possible to access the border data so I have now fixed that.