### PR TITLE
Latest Clay that includes z_offset for rendering

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
 
+    // Make sure we re-run the build script if the clay.h file changes
+    println!("cargo:rerun-if-changed=clay.h");
+
     if target_os == "windows" {
         cc::Build::new()
             .file("build.cpp")

--- a/src/bindings/bindings.rs
+++ b/src/bindings/bindings.rs
@@ -2078,13 +2078,14 @@ const _: () = {
 pub struct Clay_RenderCommand {
     pub boundingBox: Clay_BoundingBox,
     pub config: Clay_ElementConfigUnion,
-    pub text: Clay_String,
+    pub text: Clay_StringSlice,
+    pub zIndex: i32,
     pub id: u32,
     pub commandType: Clay_RenderCommandType,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_RenderCommand"][::core::mem::size_of::<Clay_RenderCommand>() - 48usize];
+    ["Size of Clay_RenderCommand"][::core::mem::size_of::<Clay_RenderCommand>() - 64usize];
     ["Alignment of Clay_RenderCommand"][::core::mem::align_of::<Clay_RenderCommand>() - 8usize];
     ["Offset of field: Clay_RenderCommand::boundingBox"]
         [::core::mem::offset_of!(Clay_RenderCommand, boundingBox) - 0usize];
@@ -2092,10 +2093,12 @@ const _: () = {
         [::core::mem::offset_of!(Clay_RenderCommand, config) - 16usize];
     ["Offset of field: Clay_RenderCommand::text"]
         [::core::mem::offset_of!(Clay_RenderCommand, text) - 24usize];
+    ["Offset of field: Clay_RenderCommand::zIndex"]
+        [::core::mem::offset_of!(Clay_RenderCommand, zIndex) - 48usize];
     ["Offset of field: Clay_RenderCommand::id"]
-        [::core::mem::offset_of!(Clay_RenderCommand, id) - 40usize];
+        [::core::mem::offset_of!(Clay_RenderCommand, id) - 52usize];
     ["Offset of field: Clay_RenderCommand::commandType"]
-        [::core::mem::offset_of!(Clay_RenderCommand, commandType) - 44usize];
+        [::core::mem::offset_of!(Clay_RenderCommand, commandType) - 56usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2106,7 +2109,7 @@ pub struct Clay__AlignClay_RenderCommand {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__AlignClay_RenderCommand"]
-        [::core::mem::size_of::<Clay__AlignClay_RenderCommand>() - 56usize];
+        [::core::mem::size_of::<Clay__AlignClay_RenderCommand>() - 72usize];
     ["Alignment of Clay__AlignClay_RenderCommand"]
         [::core::mem::align_of::<Clay__AlignClay_RenderCommand>() - 8usize];
     ["Offset of field: Clay__AlignClay_RenderCommand::c"]
@@ -2122,7 +2125,7 @@ pub struct Clay__Clay_RenderCommandWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_RenderCommandWrapper"]
-        [::core::mem::size_of::<Clay__Clay_RenderCommandWrapper>() - 48usize];
+        [::core::mem::size_of::<Clay__Clay_RenderCommandWrapper>() - 64usize];
     ["Alignment of Clay__Clay_RenderCommandWrapper"]
         [::core::mem::align_of::<Clay__Clay_RenderCommandWrapper>() - 8usize];
     ["Offset of field: Clay__Clay_RenderCommandWrapper::wrapped"]

--- a/src/bindings/bindings_debug.rs
+++ b/src/bindings/bindings_debug.rs
@@ -2078,13 +2078,14 @@ const _: () = {
 pub struct Clay_RenderCommand {
     pub boundingBox: Clay_BoundingBox,
     pub config: Clay_ElementConfigUnion,
-    pub text: Clay_String,
+    pub text: Clay_StringSlice,
+    pub zIndex: i32,
     pub id: u32,
     pub commandType: Clay_RenderCommandType,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Clay_RenderCommand"][::core::mem::size_of::<Clay_RenderCommand>() - 48usize];
+    ["Size of Clay_RenderCommand"][::core::mem::size_of::<Clay_RenderCommand>() - 64usize];
     ["Alignment of Clay_RenderCommand"][::core::mem::align_of::<Clay_RenderCommand>() - 8usize];
     ["Offset of field: Clay_RenderCommand::boundingBox"]
         [::core::mem::offset_of!(Clay_RenderCommand, boundingBox) - 0usize];
@@ -2092,10 +2093,12 @@ const _: () = {
         [::core::mem::offset_of!(Clay_RenderCommand, config) - 16usize];
     ["Offset of field: Clay_RenderCommand::text"]
         [::core::mem::offset_of!(Clay_RenderCommand, text) - 24usize];
+    ["Offset of field: Clay_RenderCommand::zIndex"]
+        [::core::mem::offset_of!(Clay_RenderCommand, zIndex) - 48usize];
     ["Offset of field: Clay_RenderCommand::id"]
-        [::core::mem::offset_of!(Clay_RenderCommand, id) - 40usize];
+        [::core::mem::offset_of!(Clay_RenderCommand, id) - 52usize];
     ["Offset of field: Clay_RenderCommand::commandType"]
-        [::core::mem::offset_of!(Clay_RenderCommand, commandType) - 44usize];
+        [::core::mem::offset_of!(Clay_RenderCommand, commandType) - 56usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -2106,7 +2109,7 @@ pub struct Clay__AlignClay_RenderCommand {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__AlignClay_RenderCommand"]
-        [::core::mem::size_of::<Clay__AlignClay_RenderCommand>() - 56usize];
+        [::core::mem::size_of::<Clay__AlignClay_RenderCommand>() - 72usize];
     ["Alignment of Clay__AlignClay_RenderCommand"]
         [::core::mem::align_of::<Clay__AlignClay_RenderCommand>() - 8usize];
     ["Offset of field: Clay__AlignClay_RenderCommand::c"]
@@ -2122,7 +2125,7 @@ pub struct Clay__Clay_RenderCommandWrapper {
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Clay__Clay_RenderCommandWrapper"]
-        [::core::mem::size_of::<Clay__Clay_RenderCommandWrapper>() - 48usize];
+        [::core::mem::size_of::<Clay__Clay_RenderCommandWrapper>() - 64usize];
     ["Alignment of Clay__Clay_RenderCommandWrapper"]
         [::core::mem::align_of::<Clay__Clay_RenderCommandWrapper>() - 8usize];
     ["Offset of field: Clay__Clay_RenderCommandWrapper::wrapped"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,8 +370,20 @@ impl From<&str> for Clay_String {
         }
     }
 }
+
 impl From<Clay_String> for &str {
     fn from(value: Clay_String) -> Self {
+        unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                value.chars as *const u8,
+                value.length as _,
+            ))
+        }
+    }
+}
+
+impl From<Clay_StringSlice> for &str {
+    fn from(value: Clay_StringSlice) -> Self {
         unsafe {
             core::str::from_utf8_unchecked(core::slice::from_raw_parts(
                 value.chars as *const u8,

--- a/src/render_commands.rs
+++ b/src/render_commands.rs
@@ -43,7 +43,7 @@ impl From<&Clay_RenderCommand> for RenderCommandConfig<'_> {
                 &mut *(value.config.borderElementConfig)
             })),
             RenderCommandType::Text => Self::Text(
-                <Clay_String as Into<&str>>::into(value.text),
+                <Clay_StringSlice as Into<&str>>::into(value.text),
                 Text::from(*unsafe { &mut *(value.config.textElementConfig) }),
             ),
             RenderCommandType::Image => Self::Image(Image::from(*unsafe {
@@ -61,6 +61,7 @@ impl From<&Clay_RenderCommand> for RenderCommandConfig<'_> {
 #[derive(Debug, Clone)]
 pub struct RenderCommand<'a> {
     pub id: u32,
+    pub z_index: i32,
     pub bounding_box: BoundingBox,
     pub config: RenderCommandConfig<'a>,
 }
@@ -69,6 +70,7 @@ impl From<Clay_RenderCommand> for RenderCommand<'_> {
     fn from(value: Clay_RenderCommand) -> Self {
         Self {
             id: value.id,
+            z_index: value.zIndex,
             bounding_box: value.boundingBox.into(),
             config: (&value).into(),
         }


### PR DESCRIPTION
* Updated to latest Clay that includes `z_offset` in the rendering
* In `build.rs` fixed so the C code gets rebuild if `clay.h` changes
* `Clay_StringSlice` is now used for the in the `RenderCommand` so added a convert to `&str` for that. I'm not sure if we want to expose the base address at some point, but I left it as is for now. 