### PR TITLE
Added static assert for percent range & updated docs

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -23,7 +23,7 @@ pub enum Sizing {
     Grow(f32, f32),
     /// Sets a fixed width/height.
     Fixed(f32),
-    /// Sets width/height as a percentage of its parent.
+    /// Sets width/height as a percentage of its parent. Value should be between `0.0` and `1.0`.
     Percent(f32),
 }
 
@@ -252,11 +252,16 @@ macro_rules! fixed {
 }
 
 /// Shorthand macro for [`Sizing::Percent`].
+/// The value has to be in range `0.0..=1.0`.
 #[macro_export]
 macro_rules! percent {
-    ($percent:expr) => {
+    ($percent:expr) => {{
+        const _: () = assert!(
+            $percent >= 0.0 && $percent <= 1.0,
+            "Percent value must be between 0.0 and 1.0 inclusive!"
+        );
         $crate::layout::Sizing::Percent($percent)
-    };
+    }};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I ran into an issue when using `percent(20.0)` as I thought the range was `0 - 100` but the range is `0 - 1` I have now updated the docs. Clay will generate an error if the range is wrong, but I also added a static assert if the value is out of range when you use the macro which is even better.