### PR TITLE
feat: raylib renderer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   build:
@@ -20,60 +20,59 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        components: rustfmt, clippy
-        override: true
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+          override: true
 
-    - name: Cache Cargo registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ matrix.rust }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-registry-
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ matrix.rust }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-    - name: Cache Cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-${{ matrix.rust }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-
+      - name: Cache Cargo build
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-${{ matrix.rust }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
 
-    - name: Install wasm32 target (if needed)
-      if: matrix.feature == 'wasm'
-      run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm32 target (if needed)
+        if: matrix.feature == 'wasm'
+        run: rustup target add wasm32-unknown-unknown
 
-    - name: Build (No features)
-      if: matrix.feature == 'default'
-      run: cargo build
+      - name: Build (No features)
+        if: matrix.feature == 'default'
+        run: cargo build
 
-    - name: Build (Debug)
-      if: matrix.feature == 'debug'
-      run: cargo build --features debug
+      - name: Build (Debug)
+        if: matrix.feature == 'debug'
+        run: cargo build --features debug
 
-    - name: Build (No std)
-      if: matrix.feature == 'no-std'
-      run: cargo build --no-default-features
+      - name: Build (No std)
+        if: matrix.feature == 'no-std'
+        run: cargo build --no-default-features
 
-    - name: Build (WASM)
-      if: matrix.feature == 'wasm'
-      run: cargo build --target wasm32-unknown-unknown
-    
-    - name: Run tests
-      run: cargo test
+      - name: Build (WASM)
+        if: matrix.feature == 'wasm'
+        run: cargo build --target wasm32-unknown-unknown
 
-    - name: Check Formatting
-      if: matrix.platform == 'ubuntu-latest'
-      run: cargo fmt --all -- --check
+      - name: Run tests
+        run: cargo test --features raylib-renderer
 
-    - name: Run Clippy Checks
-      if: matrix.platform == 'ubuntu-latest'
-      run: cargo clippy -- -D warnings
+      - name: Check Formatting
+        if: matrix.platform == 'ubuntu-latest'
+        run: cargo fmt --all -- --check
 
+      - name: Run Clippy Checks
+        if: matrix.platform == 'ubuntu-latest'
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 
+      - name: Install X11 dependencies (Linux)
+        if: matrix.platform == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxi-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev
+
       - name: Install wasm32 target (if needed)
         if: matrix.feature == 'wasm'
         run: rustup target add wasm32-unknown-unknown

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,10 @@
 {
-    "files.associations": {
-        "*.sc": "plaintext",
-        ".mpmconfig": "json",
-        "*.gui": "html",
-        "*.pm": "json",
-        "clay.h": "c"
-    }
+  "files.associations": {
+    "*.sc": "plaintext",
+    ".mpmconfig": "json",
+    "*.gui": "html",
+    "*.pm": "json",
+    "clay.h": "c"
+  },
+  "rust-analyzer.cargo.features": ["raylib-renderer"]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,23 @@ name = "clay-layout"
 version = "0.2.0"
 edition = "2021"
 description = "Rust bindings for Clay, a UI layout library written in C."
-keywords = [ "clay", "ui", "layout", "bindings", "no_std" ]
+keywords = ["clay", "ui", "layout", "bindings", "no_std"]
 repository = "https://github.com/clay-ui-rs/clay"
 readme = "README.md"
 license-file = "LICENSE.md"
-exclude = [
-    "scripts/*",
-    ".vscode/*",
-    ".github/*",
-    ".cargo/*"
-]
+exclude = ["scripts/*", ".vscode/*", ".github/*", ".cargo/*"]
 
 [build-dependencies]
 cc = "1.0"
 
 [features]
-default = [ "std" ]
+default = ["std"]
+raylib-renderer = ["raylib", "thiserror"]
 
 std = []
 wasm = []
 debug = []
+
+[dependencies]
+raylib = { version = "5.0.2", optional = true }
+thiserror = { version = "2.0.11", optional = true }

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Rust bindings for [Clay](https://github.com/nicbarker/clay), a UI layout library
 **O - In Progress, X - Done**
 
 - (O) Elements
-    - (X) Rectangle
-    - (O) Text (Waiting on an update of memory handling for text on clay part)
-    - (X) Image
-    - (X) Floating Container
-    - (X) Border Container
-    - (X) Scroll Container
-    - (X) Custom Elements
+  - (X) Rectangle
+  - (O) Text (Waiting on an update of memory handling for text on clay part)
+  - (X) Image
+  - (X) Floating Container
+  - (X) Border Container
+  - (X) Scroll Container
+  - (X) Custom Elements
 - (X) Text Measuring
 - (X) Element Ids
 - (X) Interactions
@@ -32,3 +32,12 @@ To build bindings you need to use the `generate_bindings` script. \
 It needs `bindgen` installed as a CLI, you can install it with `cargo install bindgen`. \
 Calling it will use the `clay.h` in the project root, or any `clay.h` file provided with `CLAY_HEADER_PATH`. \
 Using the clay header it will generate `src/bindings/bindings.rs` and `src/bindings/bindings_debug.rs`.
+
+## Examples
+
+Examples can be found in the `examples/` directory. They can be ran using `cargo`:
+
+```sh
+cargo run --example basic_rectangle
+cargo run --example raylib_renderer --features raylib-renderer
+```

--- a/examples/raylib_renderer.rs
+++ b/examples/raylib_renderer.rs
@@ -1,0 +1,65 @@
+use clay_layout::{grow, raylib::clay_raylib_render, Clay, Declaration};
+use raylib::prelude::*;
+
+pub fn main() {
+    let clay = Clay::new((800., 600.).into());
+
+    let (mut rl, thread) = raylib::init()
+        .resizable()
+        .size(800, 600)
+        .title("Clay Raylib Example")
+        .build();
+
+    while !rl.window_should_close() {
+        clay.layout_dimensions(
+            (rl.get_screen_width() as f32, rl.get_screen_height() as f32).into(),
+        );
+
+        let mut d = rl.begin_drawing(&thread);
+        d.clear_background(Color::WHITE);
+
+        clay.begin();
+
+        #[rustfmt::skip]
+        clay.with(
+            &Declaration::new()
+                .layout()
+                    .width(grow!())
+                    .height(grow!())
+                .end(),
+            |c| {
+                c.with(
+                    &Declaration::new()
+                        .layout()
+                            .width(grow!())
+                            .height(grow!())
+                        .end()
+                        .corner_radius()
+                            .all(24.)
+                        .end()
+                        .background_color((0xFF, 0x00, 0x00).into()),
+                    |_| {}
+                );
+
+                c.with(
+                    &Declaration::new()
+                        .layout()
+                            .width(grow!())
+                            .height(grow!())
+                        .end()
+                        .corner_radius()
+                            .all(24.)
+                        .end()
+                        .background_color((0x00, 0xFF, 0x00).into()),
+                    |_| {}
+                );
+            },
+        );
+
+        let commands = clay.end();
+
+        if let Err(e) = clay_raylib_render(&mut d, commands) {
+            eprintln!("Error: {}", e);
+        };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod bindings;
-
 pub mod color;
 pub mod elements;
 pub mod errors;
@@ -10,6 +9,9 @@ pub mod layout;
 pub mod math;
 pub mod render_commands;
 pub mod text;
+
+#[cfg(feature = "raylib-renderer")]
+pub mod raylib;
 
 mod mem;
 

--- a/src/raylib.rs
+++ b/src/raylib.rs
@@ -1,0 +1,244 @@
+use crate::render_commands::{RenderCommand, RenderCommandConfig};
+use raylib::{
+    ffi::{BeginScissorMode, EndScissorMode},
+    prelude::*,
+};
+use thiserror::Error;
+
+macro_rules! clay_to_raylib_color {
+    ($color:expr) => {
+        ::raylib::color::Color::new(
+            $color.r as u8,
+            $color.g as u8,
+            $color.b as u8,
+            $color.a as u8,
+        )
+    };
+}
+
+macro_rules! clay_to_raylib_rect {
+    ($rect:expr) => {
+        ::raylib::math::Rectangle::new(
+            $rect.x as f32,
+            $rect.y as f32,
+            $rect.width as f32,
+            $rect.height as f32,
+        )
+    };
+}
+
+#[derive(Error, Debug)]
+pub enum RaylibRendererError {
+    #[error("Failed to get image data")]
+    ImageDataError,
+}
+
+#[doc = "This is a direct* port of Clay's raylib renderer. See [the C implementation](https://github.com/nicbarker/clay/blob/main/renderers/raylib/clay_renderer_raylib.c) for more info."]
+pub fn clay_raylib_render<'a>(
+    d: &mut RaylibDrawHandle<'_>,
+    render_commands: impl Iterator<Item = RenderCommand<'a>>,
+) -> Result<(), RaylibRendererError> {
+    for command in render_commands {
+        match command.config {
+            RenderCommandConfig::Text(text) => {
+                let text_data = text.text;
+                d.draw_text(
+                    text_data,
+                    command.bounding_box.x as i32,
+                    command.bounding_box.y as i32,
+                    text.font_size.into(),
+                    clay_to_raylib_color!(text.color),
+                );
+            }
+
+            RenderCommandConfig::Image(image) => {
+                // safety: as safe as the reference implementation.
+                let texture = unsafe {
+                    let image_data = image.data as *const Texture2D;
+                    image_data
+                        .as_ref()
+                        .ok_or_else(|| RaylibRendererError::ImageDataError)?
+                };
+
+                d.draw_texture_ex(
+                    texture,
+                    Vector2::new(command.bounding_box.x, command.bounding_box.y),
+                    0.,
+                    command.bounding_box.width / texture.width as f32,
+                    // TODO: backgrond color isnt in raylib bindings?
+                    clay_to_raylib_color!(Color::WHITE),
+                );
+            }
+
+            // safety: raylib's BeginScissorMode is safe to call with any values.
+            // we need to use this here because the regular begin_scissor_mode
+            // ends the scissor mode on drop.
+            RenderCommandConfig::ScissorStart() => unsafe {
+                BeginScissorMode(
+                    command.bounding_box.x as i32,
+                    command.bounding_box.y as i32,
+                    command.bounding_box.width as i32,
+                    command.bounding_box.height as i32,
+                );
+            },
+
+            RenderCommandConfig::ScissorEnd() => unsafe {
+                EndScissorMode();
+            },
+
+            RenderCommandConfig::Rectangle(rect) => {
+                if rect.corner_radii.top_left > 0. {
+                    let radius = (rect.corner_radii.top_left * 2.)
+                        / if command.bounding_box.width > command.bounding_box.height {
+                            command.bounding_box.height
+                        } else {
+                            command.bounding_box.width
+                        };
+
+                    d.draw_rectangle_rounded(
+                        clay_to_raylib_rect!(command.bounding_box),
+                        radius,
+                        8,
+                        clay_to_raylib_color!(rect.color),
+                    );
+                } else {
+                    d.draw_rectangle(
+                        command.bounding_box.x as i32,
+                        command.bounding_box.y as i32,
+                        command.bounding_box.width as i32,
+                        command.bounding_box.height as i32,
+                        clay_to_raylib_color!(rect.color),
+                    );
+                }
+            }
+
+            RenderCommandConfig::Border(border) => {
+                if border.width.left > 0 {
+                    d.draw_rectangle(
+                        command.bounding_box.x as i32,
+                        (command.bounding_box.y + border.corner_radii.top_left) as i32,
+                        border.width.left as i32,
+                        (command.bounding_box.height
+                            - border.corner_radii.top_left
+                            - border.corner_radii.bottom_left) as i32,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.width.right > 0 {
+                    d.draw_rectangle(
+                        (command.bounding_box.x + command.bounding_box.width
+                            - border.width.right as f32) as i32,
+                        (command.bounding_box.y + border.corner_radii.top_right) as i32,
+                        border.width.right as i32,
+                        (command.bounding_box.height
+                            - border.corner_radii.top_right
+                            - border.corner_radii.bottom_right) as i32,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.width.top > 0 {
+                    d.draw_rectangle(
+                        (command.bounding_box.x + border.corner_radii.top_left) as i32,
+                        command.bounding_box.y as i32,
+                        (command.bounding_box.width
+                            - border.corner_radii.top_left
+                            - border.corner_radii.top_right) as i32,
+                        border.width.top as i32,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.width.bottom > 0 {
+                    d.draw_rectangle(
+                        (command.bounding_box.x + border.corner_radii.bottom_left) as i32,
+                        (command.bounding_box.y + command.bounding_box.height
+                            - border.width.bottom as f32) as i32,
+                        (command.bounding_box.width
+                            - border.corner_radii.bottom_left
+                            - border.corner_radii.bottom_right) as i32,
+                        border.width.bottom as i32,
+                        clay_to_raylib_color!(border.color),
+                    )
+                }
+
+                if border.corner_radii.top_left > 0. {
+                    let vec = Vector2::new(
+                        (command.bounding_box.x + border.corner_radii.top_left) as f32,
+                        (command.bounding_box.y + border.corner_radii.top_left) as f32,
+                    );
+
+                    d.draw_ring(
+                        vec,
+                        border.corner_radii.top_left - border.width.top as f32,
+                        border.corner_radii.top_left,
+                        180.,
+                        270.,
+                        10,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.corner_radii.top_right > 0. {
+                    let vec = Vector2::new(
+                        (command.bounding_box.x + command.bounding_box.width
+                            - border.corner_radii.top_right) as f32,
+                        (command.bounding_box.y + border.corner_radii.top_right) as f32,
+                    );
+
+                    d.draw_ring(
+                        vec,
+                        border.corner_radii.top_right - border.width.top as f32,
+                        border.corner_radii.top_right,
+                        270.,
+                        360.,
+                        10,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.corner_radii.bottom_left > 0. {
+                    let vec = Vector2::new(
+                        (command.bounding_box.x + border.corner_radii.bottom_left) as f32,
+                        (command.bounding_box.y + command.bounding_box.height
+                            - border.corner_radii.bottom_left) as f32,
+                    );
+
+                    d.draw_ring(
+                        vec,
+                        border.corner_radii.bottom_left - border.width.bottom as f32,
+                        border.corner_radii.bottom_left,
+                        90.,
+                        180.,
+                        10,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+
+                if border.corner_radii.bottom_right > 0. {
+                    let vec = Vector2::new(
+                        (command.bounding_box.x + command.bounding_box.width
+                            - border.corner_radii.bottom_right) as f32,
+                        (command.bounding_box.y + command.bounding_box.height
+                            - border.corner_radii.bottom_right) as f32,
+                    );
+
+                    d.draw_ring(
+                        vec,
+                        border.corner_radii.bottom_right - border.width.bottom as f32,
+                        border.corner_radii.bottom_right,
+                        0.,
+                        90.,
+                        10,
+                        clay_to_raylib_color!(border.color),
+                    );
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
this PR partially ports the raylib renderer from clay into rust. it also adds an example section in the README, and an example to demonstrate the raylib renderer.