### PR TITLE
feat!: improve typesafety on image and custom elements

### DIFF
--- a/examples/basic_rectangle.rs
+++ b/examples/basic_rectangle.rs
@@ -3,10 +3,10 @@ use clay_layout::{fixed, Clay, Declaration};
 #[rustfmt::skip]
 fn main() {
     // Create the clay instance
-    let clay = Clay::new((800., 600.).into());
+    let mut clay = Clay::new((800., 600.).into());
 
     // Begin the layout
-    clay.begin();
+    let mut clay = clay.begin::<(), ()>();
 
     // Adds a red rectangle with a corner radius of 5.
     // The Layout makes the rectangle have a width and height of 50.

--- a/examples/raylib_renderer.rs
+++ b/examples/raylib_renderer.rs
@@ -2,7 +2,7 @@ use clay_layout::{grow, raylib::clay_raylib_render, Clay, Declaration};
 use raylib::prelude::*;
 
 pub fn main() {
-    let clay = Clay::new((800., 600.).into());
+    let mut clay = Clay::new((800., 600.).into());
 
     let (mut rl, thread) = raylib::init()
         .resizable()
@@ -18,7 +18,7 @@ pub fn main() {
         let mut d = rl.begin_drawing(&thread);
         d.clear_background(Color::WHITE);
 
-        clay.begin();
+        let mut clay = clay.begin::<_, ()>();
 
         #[rustfmt::skip]
         clay.with(
@@ -58,8 +58,6 @@ pub fn main() {
 
         let commands = clay.end();
 
-        if let Err(e) = clay_raylib_render(&mut d, commands) {
-            eprintln!("Error: {}", e);
-        };
+        clay_raylib_render(&mut d, commands, |_| {})
     }
 }

--- a/examples/raylib_renderer.rs
+++ b/examples/raylib_renderer.rs
@@ -58,6 +58,6 @@ pub fn main() {
 
         let commands = clay.end();
 
-        clay_raylib_render(&mut d, commands, |_| {})
+        clay_raylib_render(&mut d, commands, |_, _| {})
     }
 }

--- a/src/bindings/bindings.rs
+++ b/src/bindings/bindings.rs
@@ -684,7 +684,7 @@ pub struct Clay__Clay_TextElementConfigWrapper {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_ImageElementConfig {
-    pub imageData: *mut ::core::ffi::c_void,
+    pub imageData: *const ::core::ffi::c_void,
     pub sourceDimensions: Clay_Dimensions,
 }
 #[repr(C)]
@@ -745,7 +745,7 @@ pub struct Clay__Clay_FloatingElementConfigWrapper {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_CustomElementConfig {
-    pub customData: *mut ::core::ffi::c_void,
+    pub customData: *const ::core::ffi::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/bindings/bindings_debug.rs
+++ b/src/bindings/bindings_debug.rs
@@ -684,7 +684,7 @@ pub struct Clay__Clay_TextElementConfigWrapper {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_ImageElementConfig {
-    pub imageData: *mut ::core::ffi::c_void,
+    pub imageData: *const ::core::ffi::c_void,
     pub sourceDimensions: Clay_Dimensions,
 }
 #[repr(C)]
@@ -745,7 +745,7 @@ pub struct Clay__Clay_FloatingElementConfigWrapper {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Clay_CustomElementConfig {
-    pub customData: *mut ::core::ffi::c_void,
+    pub customData: *const ::core::ffi::c_void,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,14 +1,14 @@
 use crate::{bindings::*, color::Color, Declaration, Dimensions, Vector2};
 
 /// Builder for configuring border properties of a `Declaration`.
-pub struct BorderBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+pub struct BorderBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+    parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'a, ImageElementData, CustomElementData> BorderBuilder<'a, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> BorderBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
     /// Creates a new `BorderBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
+    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
         BorderBuilder { parent }
     }
 
@@ -66,20 +66,20 @@ impl<'a, ImageElementData, CustomElementData> BorderBuilder<'a, ImageElementData
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
+    pub fn end(&mut self) -> &mut Declaration<'render, ImageElementData, CustomElementData> {
         self.parent
     }
 }
 
 /// Builder for configuring image properties in a `Declaration`.
-pub struct ImageBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+pub struct ImageBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+    parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'a, ImageElementData, CustomElementData> ImageBuilder<'a, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> ImageBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
     /// Creates a new `ImageBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
+    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
         ImageBuilder { parent }
     }
 
@@ -93,20 +93,15 @@ impl<'a, ImageElementData, CustomElementData> ImageBuilder<'a, ImageElementData,
     /// Sets the image data.
     /// The data must be created using [`Clay::data`].
     #[inline]
-    pub fn data(&mut self, data: &'a mut ImageElementData) -> &mut Self {
+    pub fn data(&mut self, data: &'render mut ImageElementData) -> &mut Self {
         self.parent.inner.image.imageData = (data as *mut ImageElementData).cast();
         self
     }
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
+    pub fn end(&mut self) -> &mut Declaration<'render, ImageElementData, CustomElementData> {
         self.parent
     }
-}
-
-/// Builder for configuring image properties in a `Declaration`.
-pub struct CustomElementBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
 
@@ -159,14 +154,14 @@ pub enum FloatingAttachToElement {
 }
 
 /// Builder for configuring floating element properties in a `Declaration`.
-pub struct FloatingBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+pub struct FloatingBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+    parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'a, ImageElementData, CustomElementData> FloatingBuilder<'a, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> FloatingBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
     /// Creates a new `FloatingBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
+    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
         FloatingBuilder { parent }
     }
 
@@ -231,20 +226,20 @@ impl<'a, ImageElementData, CustomElementData> FloatingBuilder<'a, ImageElementDa
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
+    pub fn end(&mut self) -> &mut Declaration<'render, ImageElementData, CustomElementData> {
         self.parent
     }
 }
 
 /// Builder for configuring corner radius properties in a `Declaration`.
-pub struct CornerRadiusBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+pub struct CornerRadiusBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+    parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'a, ImageElementData, CustomElementData> CornerRadiusBuilder<'a, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> CornerRadiusBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
     /// Creates a new `CornerRadiusBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
+    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
         CornerRadiusBuilder { parent }
     }
 
@@ -288,7 +283,7 @@ impl<'a, ImageElementData, CustomElementData> CornerRadiusBuilder<'a, ImageEleme
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
+    pub fn end(&mut self) -> &mut Declaration<'render, ImageElementData, CustomElementData> {
         self.parent
     }
 }

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -93,8 +93,8 @@ impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'rende
     /// Sets the image data.
     /// The data must be created using [`Clay::data`].
     #[inline]
-    pub fn data(&mut self, data: &'render mut ImageElementData) -> &mut Self {
-        self.parent.inner.image.imageData = (data as *mut ImageElementData).cast();
+    pub fn data(&mut self, data: &'render ImageElementData) -> &mut Self {
+        self.parent.inner.image.imageData = (data as *const ImageElementData).cast();
         self
     }
     /// Returns the modified `Declaration`.

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,14 +1,23 @@
 use crate::{bindings::*, color::Color, Declaration, Dimensions, Vector2};
 
 /// Builder for configuring border properties of a `Declaration`.
-pub struct BorderBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+pub struct BorderBuilder<
+    'declaration,
+    'render,
+    ImageElementData: 'render,
+    CustomElementData: 'render,
+> {
     parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> BorderBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render>
+    BorderBuilder<'declaration, 'render, ImageElementData, CustomElementData>
+{
     /// Creates a new `BorderBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
+    pub fn new(
+        parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
+    ) -> Self {
         BorderBuilder { parent }
     }
 
@@ -72,14 +81,23 @@ impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'rende
 }
 
 /// Builder for configuring image properties in a `Declaration`.
-pub struct ImageBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+pub struct ImageBuilder<
+    'declaration,
+    'render,
+    ImageElementData: 'render,
+    CustomElementData: 'render,
+> {
     parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> ImageBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render>
+    ImageBuilder<'declaration, 'render, ImageElementData, CustomElementData>
+{
     /// Creates a new `ImageBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
+    pub fn new(
+        parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
+    ) -> Self {
         ImageBuilder { parent }
     }
 
@@ -103,7 +121,6 @@ impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'rende
         self.parent
     }
 }
-
 
 /// Represents different attachment points for floating elements.
 #[derive(Debug, Clone, Copy)]
@@ -154,14 +171,23 @@ pub enum FloatingAttachToElement {
 }
 
 /// Builder for configuring floating element properties in a `Declaration`.
-pub struct FloatingBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+pub struct FloatingBuilder<
+    'declaration,
+    'render,
+    ImageElementData: 'render,
+    CustomElementData: 'render,
+> {
     parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> FloatingBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render>
+    FloatingBuilder<'declaration, 'render, ImageElementData, CustomElementData>
+{
     /// Creates a new `FloatingBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
+    pub fn new(
+        parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
+    ) -> Self {
         FloatingBuilder { parent }
     }
 
@@ -232,14 +258,23 @@ impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'rende
 }
 
 /// Builder for configuring corner radius properties in a `Declaration`.
-pub struct CornerRadiusBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+pub struct CornerRadiusBuilder<
+    'declaration,
+    'render,
+    ImageElementData: 'render,
+    CustomElementData: 'render,
+> {
     parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> CornerRadiusBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render>
+    CornerRadiusBuilder<'declaration, 'render, ImageElementData, CustomElementData>
+{
     /// Creates a new `CornerRadiusBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
+    pub fn new(
+        parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
+    ) -> Self {
         CornerRadiusBuilder { parent }
     }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,15 +1,14 @@
-use crate::{bindings::*, color::Color, DataRef, Declaration, Dimensions, Vector2};
-use core::ffi::c_void;
+use crate::{bindings::*, color::Color, Declaration, Dimensions, Vector2};
 
 /// Builder for configuring border properties of a `Declaration`.
-pub struct BorderBuilder<'a> {
-    parent: &'a mut Declaration,
+pub struct BorderBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
-impl BorderBuilder<'_> {
+impl<'a, ImageElementData, CustomElementData> BorderBuilder<'a, ImageElementData, CustomElementData> {
     /// Creates a new `BorderBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &mut Declaration) -> BorderBuilder {
+    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
         BorderBuilder { parent }
     }
 
@@ -67,20 +66,20 @@ impl BorderBuilder<'_> {
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration {
+    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
         self.parent
     }
 }
 
 /// Builder for configuring image properties in a `Declaration`.
-pub struct ImageBuilder<'a> {
-    parent: &'a mut Declaration,
+pub struct ImageBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
-impl ImageBuilder<'_> {
+impl<'a, ImageElementData, CustomElementData> ImageBuilder<'a, ImageElementData, CustomElementData> {
     /// Creates a new `ImageBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &mut Declaration) -> ImageBuilder {
+    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
         ImageBuilder { parent }
     }
 
@@ -94,27 +93,22 @@ impl ImageBuilder<'_> {
     /// Sets the image data.
     /// The data must be created using [`Clay::data`].
     #[inline]
-    pub fn data(&mut self, data: DataRef) -> &mut Self {
-        self.parent.inner.image.imageData = data.ptr as *mut c_void;
+    pub fn data(&mut self, data: &'a mut ImageElementData) -> &mut Self {
+        self.parent.inner.image.imageData = (data as *mut ImageElementData).cast();
         self
     }
-
-    /// Sets the image data using a raw pointer.
-    ///
-    /// # Safety
-    /// This function is unsafe because it accepts a raw pointer.
-    #[inline]
-    pub unsafe fn data_ptr(&mut self, data: *const c_void) -> &mut Self {
-        self.parent.inner.image.imageData = data as _;
-        self
-    }
-
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration {
+    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
         self.parent
     }
 }
+
+/// Builder for configuring image properties in a `Declaration`.
+pub struct CustomElementBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+}
+
 
 /// Represents different attachment points for floating elements.
 #[derive(Debug, Clone, Copy)]
@@ -165,14 +159,14 @@ pub enum FloatingAttachToElement {
 }
 
 /// Builder for configuring floating element properties in a `Declaration`.
-pub struct FloatingBuilder<'a> {
-    parent: &'a mut Declaration,
+pub struct FloatingBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
-impl FloatingBuilder<'_> {
+impl<'a, ImageElementData, CustomElementData> FloatingBuilder<'a, ImageElementData, CustomElementData> {
     /// Creates a new `FloatingBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &mut Declaration) -> FloatingBuilder {
+    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
         FloatingBuilder { parent }
     }
 
@@ -237,20 +231,20 @@ impl FloatingBuilder<'_> {
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration {
+    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
         self.parent
     }
 }
 
 /// Builder for configuring corner radius properties in a `Declaration`.
-pub struct CornerRadiusBuilder<'a> {
-    parent: &'a mut Declaration,
+pub struct CornerRadiusBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
-impl CornerRadiusBuilder<'_> {
+impl<'a, ImageElementData, CustomElementData> CornerRadiusBuilder<'a, ImageElementData, CustomElementData> {
     /// Creates a new `CornerRadiusBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &mut Declaration) -> CornerRadiusBuilder {
+    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
         CornerRadiusBuilder { parent }
     }
 
@@ -294,7 +288,7 @@ impl CornerRadiusBuilder<'_> {
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration {
+    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
         self.parent
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -151,14 +151,14 @@ pub enum LayoutDirection {
 }
 
 /// Builder for configuring layout properties in a `Declaration`.
-pub struct LayoutBuilder<'a, ImageElementData, CustomElementData> {
-    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
+pub struct LayoutBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+    parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'a, ImageElementData, CustomElementData> LayoutBuilder<'a, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> LayoutBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
     /// Creates a new `LayoutBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
+    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
         LayoutBuilder { parent }
     }
 
@@ -210,7 +210,7 @@ impl<'a, ImageElementData, CustomElementData> LayoutBuilder<'a, ImageElementData
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
+    pub fn end(&mut self) -> &mut Declaration<'render, ImageElementData, CustomElementData> {
         self.parent
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -151,14 +151,14 @@ pub enum LayoutDirection {
 }
 
 /// Builder for configuring layout properties in a `Declaration`.
-pub struct LayoutBuilder<'a> {
-    parent: &'a mut Declaration,
+pub struct LayoutBuilder<'a, ImageElementData, CustomElementData> {
+    parent: &'a mut Declaration<ImageElementData, CustomElementData>,
 }
 
-impl LayoutBuilder<'_> {
+impl<'a, ImageElementData, CustomElementData> LayoutBuilder<'a, ImageElementData, CustomElementData> {
     /// Creates a new `LayoutBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &mut Declaration) -> LayoutBuilder {
+    pub fn new(parent: &'a mut Declaration<ImageElementData, CustomElementData>) -> Self {
         LayoutBuilder { parent }
     }
 
@@ -210,7 +210,7 @@ impl LayoutBuilder<'_> {
 
     /// Returns the modified `Declaration`.
     #[inline]
-    pub fn end(&mut self) -> &mut Declaration {
+    pub fn end(&mut self) -> &mut Declaration<ImageElementData, CustomElementData> {
         self.parent
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -151,14 +151,23 @@ pub enum LayoutDirection {
 }
 
 /// Builder for configuring layout properties in a `Declaration`.
-pub struct LayoutBuilder<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> {
+pub struct LayoutBuilder<
+    'declaration,
+    'render,
+    ImageElementData: 'render,
+    CustomElementData: 'render,
+> {
     parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
 }
 
-impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render> LayoutBuilder<'declaration, 'render, ImageElementData, CustomElementData> {
+impl<'declaration, 'render, ImageElementData: 'render, CustomElementData: 'render>
+    LayoutBuilder<'declaration, 'render, ImageElementData, CustomElementData>
+{
     /// Creates a new `LayoutBuilder` with the given parent `Declaration`.
     #[inline]
-    pub fn new(parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>) -> Self {
+    pub fn new(
+        parent: &'declaration mut Declaration<'render, ImageElementData, CustomElementData>,
+    ) -> Self {
         LayoutBuilder { parent }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,9 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         let array = unsafe { Clay_EndLayout() };
         self.dropped = true;
         let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };
-        slice.iter().map(|command| unsafe { RenderCommand::from_clay_render_command(*command) })
+        slice
+            .iter()
+            .map(|command| unsafe { RenderCommand::from_clay_render_command(*command) })
     }
 
     /// Generates a unique ID based on the given `label`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     ///
     /// This ID is global and must be unique across the entire scope.
     #[inline]
-    pub fn id(&self, label: &'clay str) -> id::Id {
+    pub fn id(&self, label: &'render str) -> id::Id {
         id::Id::new(label)
     }
 
@@ -227,7 +227,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     ///
     /// This is useful when multiple elements share the same label but need distinct IDs.
     #[inline]
-    pub fn id_index(&self, label: &'clay str, index: u32) -> id::Id {
+    pub fn id_index(&self, label: &'render str, index: u32) -> id::Id {
         id::Id::new_index(label, index)
     }
 
@@ -235,7 +235,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     ///
     /// The ID is unique within a specific local scope but not globally.
     #[inline]
-    pub fn id_local(&self, label: &'clay str) -> id::Id {
+    pub fn id_local(&self, label: &'render str) -> id::Id {
         id::Id::new_index_local(label, 0)
     }
 
@@ -243,12 +243,12 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     ///
     /// This is useful for differentiating elements within a local scope while keeping their labels consistent.
     #[inline]
-    pub fn id_index_local(&self, label: &'clay str, index: u32) -> id::Id {
+    pub fn id_index_local(&self, label: &'render str, index: u32) -> id::Id {
         id::Id::new_index_local(label, index)
     }
 
     /// Adds a text element to the current open element or to the root layout
-    pub fn text(&self, text: &str, config: TextElementConfig) {
+    pub fn text(&self, text: &'render str, config: TextElementConfig) {
         unsafe { Clay__OpenTextElement(text.into(), config.into()) };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,21 +374,21 @@ impl Clay {
 
     /// Sets the maximum number of element that clay supports
     /// **Use only if you know what you are doing or your getting errors from clay**
-    pub fn max_element_count(&self, max_element_count: u32) {
+    pub fn max_element_count(&mut self, max_element_count: u32) {
         unsafe {
             Clay_SetMaxElementCount(max_element_count as _);
         }
     }
     /// Sets the capacity of the cache used for text in the measure text function
     /// **Use only if you know what you are doing or your getting errors from clay**
-    pub fn max_measure_text_cache_word_count(&self, count: u32) {
+    pub fn max_measure_text_cache_word_count(&mut self, count: u32) {
         unsafe {
             Clay_SetMaxElementCount(count as _);
         }
     }
 
     /// Enables or disables the debug mode of clay
-    pub fn enable_debug_mode(&self, enable: bool) {
+    pub fn enable_debug_mode(&mut self, enable: bool) {
         unsafe {
             Clay_SetDebugModeEnabled(enable);
         }
@@ -396,20 +396,20 @@ impl Clay {
 
     /// Sets the dimensions of the global layout, use if, for example the window size you render to
     /// changed
-    pub fn layout_dimensions(&self, dimensions: Dimensions) {
+    pub fn layout_dimensions(&mut self, dimensions: Dimensions) {
         unsafe {
             Clay_SetLayoutDimensions(dimensions.into());
         }
     }
     /// Updates the state of the pointer for clay. Used to update scroll containers and for
     /// interactions functions
-    pub fn pointer_state(&self, position: Vector2, is_down: bool) {
+    pub fn pointer_state(&mut self, position: Vector2, is_down: bool) {
         unsafe {
             Clay_SetPointerState(position.into(), is_down);
         }
     }
     pub fn update_scroll_containers(
-        &self,
+        &mut self,
         drag_scrolling_enabled: bool,
         scroll_delta: Vector2,
         delta_time: f32,
@@ -507,7 +507,7 @@ mod tests {
             Dimensions::default()
         });
 
-        clay.begin();
+        let mut clay = clay.begin::<(), ()>();
 
         clay.with(&Declaration::new()
             .id(clay.id("parent_rect"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub use color::Color;
 use text::TextConfig;
 
 use text::TextElementConfig;
-
 #[derive(Copy, Clone)]
 pub struct Declaration<ImageElementData, CustomElementData> {
     inner: Clay_ElementDeclaration,
@@ -58,6 +57,12 @@ impl<ImageElementData, CustomElementData> Declaration<ImageElementData, CustomEl
     #[inline]
     pub fn id(&mut self, id: Id) -> &mut Self {
         self.inner.id = id.id;
+        self
+    }
+
+    #[inline]
+    pub fn custom_element(&mut self, data: &mut CustomElementData) -> &mut Self {
+        self.inner.custom.customData = (data as *mut CustomElementData).cast();
         self
     }
 
@@ -138,11 +143,6 @@ unsafe extern "C" fn error_handler(error_data: Clay_ErrorData) {
     panic!("Clay Error: (type: {:?}) {}", error.type_, error.text);
 }
 
-pub struct DataRef<'a> {
-    pub(crate) ptr: *const core::ffi::c_void,
-    _phantom: core::marker::PhantomData<&'a ()>,
-}
-
 #[allow(dead_code)]
 pub struct Clay<'a, ImageElementData, CustomElementData> {
     /// Memory used internally by clay
@@ -220,15 +220,6 @@ impl<'a, ImageElementData: 'a, CustomElementData: 'a> Clay<'a, ImageElementData,
             context,
             _phantom: core::marker::PhantomData,
             text_measure_callback: None,
-        }
-    }
-
-    /// Get a reference to the data to pass to clay or the builders. This is to ensure that the
-    /// data is not dropped before clay is done with it.
-    pub fn data<T>(&self, data: &T) -> DataRef<'a> {
-        DataRef {
-            ptr: data as *const T as *const core::ffi::c_void,
-            _phantom: core::marker::PhantomData,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@ pub struct Declaration<'render, ImageElementData: 'render, CustomElementData: 'r
     _phantom: PhantomData<(&'render CustomElementData, &'render ImageElementData)>,
 }
 
-impl<'render, ImageElementData: 'render, CustomElementData: 'render> Declaration<'render, ImageElementData, CustomElementData> {
+impl<'render, ImageElementData: 'render, CustomElementData: 'render>
+    Declaration<'render, ImageElementData, CustomElementData>
+{
     #[inline]
     pub fn new() -> Self {
         crate::mem::zeroed_init()
@@ -67,22 +69,30 @@ impl<'render, ImageElementData: 'render, CustomElementData: 'render> Declaration
     }
 
     #[inline]
-    pub fn layout(&mut self) -> layout::LayoutBuilder<'_, 'render, ImageElementData, CustomElementData> {
+    pub fn layout(
+        &mut self,
+    ) -> layout::LayoutBuilder<'_, 'render, ImageElementData, CustomElementData> {
         layout::LayoutBuilder::new(self)
     }
 
     #[inline]
-    pub fn image(&mut self) -> elements::ImageBuilder<'_, 'render, ImageElementData, CustomElementData> {
+    pub fn image(
+        &mut self,
+    ) -> elements::ImageBuilder<'_, 'render, ImageElementData, CustomElementData> {
         elements::ImageBuilder::new(self)
     }
 
     #[inline]
-    pub fn floating(&mut self) -> elements::FloatingBuilder<'_, 'render, ImageElementData, CustomElementData> {
+    pub fn floating(
+        &mut self,
+    ) -> elements::FloatingBuilder<'_, 'render, ImageElementData, CustomElementData> {
         elements::FloatingBuilder::new(self)
     }
 
     #[inline]
-    pub fn border(&mut self) -> elements::BorderBuilder<'_, 'render, ImageElementData, CustomElementData> {
+    pub fn border(
+        &mut self,
+    ) -> elements::BorderBuilder<'_, 'render, ImageElementData, CustomElementData> {
         elements::BorderBuilder::new(self)
     }
 
@@ -168,13 +178,15 @@ pub struct ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData> 
 }
 
 impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'render>
-    ClayLayoutScope<'clay,'render, ImageElementData, CustomElementData>
+    ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>
 {
     /// Create an element, passing it's config and a function to add childrens
     /// ```
     /// // TODO: Add Example
     /// ```
-    pub fn with<F: FnOnce(&mut ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>)>(
+    pub fn with<
+        F: FnOnce(&mut ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>),
+    >(
         &mut self,
         declaration: &Declaration<'render, ImageElementData, CustomElementData>,
         f: F,
@@ -238,23 +250,26 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         unsafe { Clay__OpenTextElement(text.into(), config.into()) };
     }
 }
-impl<'clay, 'render, ImageElementData, CustomElementData> Drop for ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData> {
+impl<'clay, 'render, ImageElementData, CustomElementData> Drop
+    for ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>
+{
     fn drop(&mut self) {
         if !self.dropped {
-            unsafe { Clay_EndLayout(); }
-        }   
+            unsafe {
+                Clay_EndLayout();
+            }
+        }
     }
 }
 impl Clay {
     pub fn begin<'render, ImageElementData: 'render, CustomElementData: 'render>(
         &mut self,
-    ) -> ClayLayoutScope<'_, 'render, ImageElementData, CustomElementData>
-    {   
+    ) -> ClayLayoutScope<'_, 'render, ImageElementData, CustomElementData> {
         unsafe { Clay_BeginLayout() };
         ClayLayoutScope {
             clay: self,
             _phantom: core::marker::PhantomData,
-            dropped: false
+            dropped: false,
         }
     }
 
@@ -313,10 +328,13 @@ impl Clay {
 
     /// Set the callback for text measurement with user data
     #[cfg(feature = "std")]
-    pub fn set_measure_text_function_user_data<'clay, F, T>(&'clay mut self, userdata: T, callback: F)
-    where
+    pub fn set_measure_text_function_user_data<'clay, F, T>(
+        &'clay mut self,
+        userdata: T,
+        callback: F,
+    ) where
         F: Fn(&str, &TextConfig, &'clay mut T) -> Dimensions + 'static,
-        T: 'clay ,
+        T: 'clay,
     {
         // Box the callback and userdata together
         let boxed = Box::new((callback, userdata));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,20 +161,20 @@ pub struct Clay {
     text_measure_callback: Option<*const core::ffi::c_void>,
 }
 
-pub struct BegunClay<'clay, 'render, ImageElementData, CustomElementData> {
+pub struct ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData> {
     clay: &'clay mut Clay,
     _phantom: core::marker::PhantomData<(&'render ImageElementData, &'render CustomElementData)>,
     dropped: bool,
 }
 
 impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'render>
-    BegunClay<'clay,'render, ImageElementData, CustomElementData>
+    ClayLayoutScope<'clay,'render, ImageElementData, CustomElementData>
 {
     /// Create an element, passing it's config and a function to add childrens
     /// ```
     /// // TODO: Add Example
     /// ```
-    pub fn with<F: FnOnce(&mut BegunClay<'clay, 'render, ImageElementData, CustomElementData>)>(
+    pub fn with<F: FnOnce(&mut ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>)>(
         &mut self,
         declaration: &Declaration<'render, ImageElementData, CustomElementData>,
         f: F,
@@ -238,7 +238,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         unsafe { Clay__OpenTextElement(text.into(), config.into()) };
     }
 }
-impl<'clay, 'render, ImageElementData, CustomElementData> Drop for BegunClay<'clay, 'render, ImageElementData, CustomElementData> {
+impl<'clay, 'render, ImageElementData, CustomElementData> Drop for ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData> {
     fn drop(&mut self) {
         if !self.dropped {
             unsafe { Clay_EndLayout(); }
@@ -248,10 +248,10 @@ impl<'clay, 'render, ImageElementData, CustomElementData> Drop for BegunClay<'cl
 impl Clay {
     pub fn begin<'render, ImageElementData: 'render, CustomElementData: 'render>(
         &mut self,
-    ) -> BegunClay<'_, 'render, ImageElementData, CustomElementData>
-    {
+    ) -> ClayLayoutScope<'_, 'render, ImageElementData, CustomElementData>
+    {   
         unsafe { Clay_BeginLayout() };
-        BegunClay {
+        ClayLayoutScope {
             clay: self,
             _phantom: core::marker::PhantomData,
             dropped: false
@@ -302,7 +302,6 @@ impl Clay {
         Self {
             _memory: memory,
             context,
-            _phantom: core::marker::PhantomData,
             text_measure_callback: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,8 @@ impl<'render, ImageElementData: 'render, CustomElementData: 'render> Declaration
     }
 
     #[inline]
-    pub fn custom_element(&mut self, data: &mut CustomElementData) -> &mut Self {
-        self.inner.custom.customData = (data as *mut CustomElementData).cast();
+    pub fn custom_element(&mut self, data: &'render CustomElementData) -> &mut Self {
+        self.inner.custom.customData = (data as *const CustomElementData).cast();
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,8 @@ impl<'render, ImageElementData: 'render, CustomElementData: 'render>
     }
 }
 
-impl<'render, ImageElementData, CustomElementData> Default
-    for Declaration<'render, ImageElementData, CustomElementData>
+impl<ImageElementData, CustomElementData> Default
+    for Declaration<'_, ImageElementData, CustomElementData>
 {
     fn default() -> Self {
         Self::new()
@@ -210,7 +210,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         let array = unsafe { Clay_EndLayout() };
         self.dropped = true;
         let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };
-        slice.iter().map(|command| RenderCommand::from(*command))
+        slice.iter().map(|command| unsafe { RenderCommand::from_clay_render_command(*command) })
     }
 
     /// Generates a unique ID based on the given `label`.
@@ -250,8 +250,8 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         unsafe { Clay__OpenTextElement(text.into(), config.into()) };
     }
 }
-impl<'clay, 'render, ImageElementData, CustomElementData> Drop
-    for ClayLayoutScope<'clay, 'render, ImageElementData, CustomElementData>
+impl<ImageElementData, CustomElementData> Drop
+    for ClayLayoutScope<'_, '_, ImageElementData, CustomElementData>
 {
     fn drop(&mut self) {
         if !self.dropped {

--- a/src/raylib.rs
+++ b/src/raylib.rs
@@ -3,7 +3,6 @@ use raylib::{
     ffi::{BeginScissorMode, EndScissorMode},
     prelude::*,
 };
-use thiserror::Error;
 
 macro_rules! clay_to_raylib_color {
     ($color:expr) => {
@@ -28,7 +27,7 @@ macro_rules! clay_to_raylib_rect {
 }
 
 #[doc = "This is a direct* port of Clay's raylib renderer. See [the C implementation](https://github.com/nicbarker/clay/blob/main/renderers/raylib/clay_renderer_raylib.c) for more info."]
-pub fn clay_raylib_render<'a, CustomElementData>(
+pub fn clay_raylib_render<'a, CustomElementData: 'a>(
     d: &mut RaylibDrawHandle<'_>,
     render_commands: impl Iterator<Item = RenderCommand<'a, Texture2D, CustomElementData>>,
     mut handle_custom_element: impl FnMut(&CustomElementData) -> ()
@@ -224,7 +223,7 @@ pub fn clay_raylib_render<'a, CustomElementData>(
                     );
                 }
             }
-            RenderCommandConfig::Custom(custom) => handle_custom_element(custom),
+            RenderCommandConfig::Custom(custom) => handle_custom_element(custom.data),
             RenderCommandConfig::None() => {}
         }
     }

--- a/src/raylib.rs
+++ b/src/raylib.rs
@@ -30,7 +30,7 @@ macro_rules! clay_to_raylib_rect {
 pub fn clay_raylib_render<'a, CustomElementData: 'a>(
     d: &mut RaylibDrawHandle<'_>,
     render_commands: impl Iterator<Item = RenderCommand<'a, Texture2D, CustomElementData>>,
-    mut handle_custom_element: impl FnMut(&CustomElementData) -> ()
+    mut handle_custom_element: impl FnMut(&CustomElementData) -> (),
 ) {
     for command in render_commands {
         match command.config {

--- a/src/raylib.rs
+++ b/src/raylib.rs
@@ -27,10 +27,10 @@ macro_rules! clay_to_raylib_rect {
 }
 
 #[doc = "This is a direct* port of Clay's raylib renderer. See [the C implementation](https://github.com/nicbarker/clay/blob/main/renderers/raylib/clay_renderer_raylib.c) for more info."]
-pub fn clay_raylib_render<'a, CustomElementData: 'a>(
-    d: &mut RaylibDrawHandle<'_>,
+pub fn clay_raylib_render<'rl, 'a, CustomElementData: 'a>(
+    d: &mut RaylibDrawHandle<'rl>,
     render_commands: impl Iterator<Item = RenderCommand<'a, Texture2D, CustomElementData>>,
-    mut handle_custom_element: impl FnMut(&CustomElementData) -> (),
+    mut handle_custom_element: impl FnMut(&CustomElementData, &mut RaylibDrawHandle<'rl>),
 ) {
     for command in render_commands {
         match command.config {
@@ -223,7 +223,7 @@ pub fn clay_raylib_render<'a, CustomElementData: 'a>(
                     );
                 }
             }
-            RenderCommandConfig::Custom(custom) => handle_custom_element(custom.data),
+            RenderCommandConfig::Custom(custom) => handle_custom_element(custom.data, &mut *d),
             RenderCommandConfig::None() => {}
         }
     }

--- a/src/render_commands.rs
+++ b/src/render_commands.rs
@@ -177,7 +177,8 @@ pub enum RenderCommandConfig<'a, ImageElementData, CustomElementData> {
     Custom(Custom<'a, CustomElementData>),
 }
 
-impl<ImageElementData, CustomElementData> RenderCommandConfig<'_, ImageElementData, CustomElementData>
+impl<ImageElementData, CustomElementData>
+    RenderCommandConfig<'_, ImageElementData, CustomElementData>
 {
     #[allow(non_upper_case_globals)]
     pub(crate) unsafe fn from_clay_render_command(value: &Clay_RenderCommand) -> Self {
@@ -197,9 +198,9 @@ impl<ImageElementData, CustomElementData> RenderCommandConfig<'_, ImageElementDa
             }
             Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_SCISSOR_START => Self::ScissorStart(),
             Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_SCISSOR_END => Self::ScissorEnd(),
-            Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_CUSTOM => {
-                Self::Custom(unsafe { Custom::from_clay_custom_element_data(value.renderData.custom) })
-            }
+            Clay_RenderCommandType_CLAY_RENDER_COMMAND_TYPE_CUSTOM => Self::Custom(unsafe {
+                Custom::from_clay_custom_element_data(value.renderData.custom)
+            }),
             _ => unreachable!(),
         }
     }
@@ -219,8 +220,7 @@ pub struct RenderCommand<'a, ImageElementData, CustomElementData> {
     pub z_index: i16,
 }
 
-impl<ImageElementData, CustomElementData> RenderCommand<'_, ImageElementData, CustomElementData>
-{
+impl<ImageElementData, CustomElementData> RenderCommand<'_, ImageElementData, CustomElementData> {
     pub(crate) unsafe fn from_clay_render_command(value: Clay_RenderCommand) -> Self {
         Self {
             id: value.id,


### PR DESCRIPTION
This PR improves the typesafety of the render commands, more specifically, it ensures that what you put inside the declaration is what the renderer is expecting.

For that to be possible, 2 new generic types were added to the Clay struct, ImageElementData and CustomElementData, which then are forwarded to the ImageBuilder struct and Declaration::custom_data function and to the RenderCommand struct. With this change we can prevent undefined behavior when rendering images and custom elements at compile time.

This was not the only change, additionally, the custom_element function was also added back because it was missing from the Declaration struct