### PR TITLE
Fixed crash on Drop

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /out/
 Cargo.lock
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,8 @@ impl Clay {
         F: Fn(&str, &TextConfig) -> Dimensions + 'static,
     {
         // Box the callback and userdata together
-        let boxed = Box::new(callback);
+        // Tuple here is to prevent Rust ZST optimization from breaking the C ABI
+        let boxed = Box::new((callback, 0usize));
 
         // Get a raw pointer to the boxed data
         let user_data_ptr = Box::into_raw(boxed) as *mut core::ffi::c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,7 +554,6 @@ impl From<Clay_StringSlice> for &str {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
     use super::*;
     use color::Color;
     use layout::{Padding, Sizing};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,8 +515,9 @@ impl Drop for Clay {
         unsafe {
             if let Some(ptr) = self.text_measure_callback {
                 let _ = Box::from_raw(ptr as *mut (usize, usize));
-                Clay_SetCurrentContext(core::ptr::null_mut() as _);
             }
+
+            Clay_SetCurrentContext(core::ptr::null_mut() as _);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ impl Clay {
         F: Fn(&str, &TextConfig) -> Dimensions + 'static,
     {
         // Box the callback and userdata together
-        // Tuple here is to prevent Rust ZST optimization from breaking the C ABI
+        // Tuple here is to prevent Rust ZST optimization from breaking getting a raw pointer
         let boxed = Box::new((callback, 0usize));
 
         // Get a raw pointer to the boxed data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,9 @@ where
         text_slice.length as _,
     ));
 
-    let callback: &mut F = &mut *(user_data as *mut F);
+    let tuple = &*(user_data as *const (F, usize));
     let text_config = TextConfig::from(*config);
-    callback(text, &text_config).into()
+    (tuple.0)(text, &text_config).into()
 }
 
 unsafe extern "C" fn error_handler(error_data: Clay_ErrorData) {


### PR DESCRIPTION
When passing in a closure with no capture Rust ZST would optimize this so no real pointer would be returned from the Box which would cause a crash later when dropping it
Also added a new test for this, but had to set thread tests count to 1 because Clay isn't thread-safe yet even if it has it's context stuff added to it.