### PR TITLE
added function collect()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         }
     }
 
-    pub fn end_layout<'commands>(&mut self) -> Vec<RenderCommand<'commands, ImageElementData, CustomElementData>> {
+    pub fn collect<'commands>(&mut self) -> Vec<RenderCommand<'commands, ImageElementData, CustomElementData>> {
         let array = unsafe { Clay_EndLayout() };
         self.dropped = true;
         let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,12 +227,15 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         }
     }
 
-    pub fn collect<'commands>(&mut self) -> Vec<RenderCommand<'commands, ImageElementData, CustomElementData>> {
+    pub fn collect<'commands>(
+        &mut self,
+    ) -> Vec<RenderCommand<'commands, ImageElementData, CustomElementData>> {
         let array = unsafe { Clay_EndLayout() };
         self.dropped = true;
         let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };
-        let mut commands = Vec::<RenderCommand<'commands, ImageElementData, CustomElementData>>::new();
-        for command in slice.iter(){    
+        let mut commands =
+            Vec::<RenderCommand<'commands, ImageElementData, CustomElementData>>::new();
+        for command in slice.iter() {
             commands.push(unsafe { RenderCommand::from_clay_render_command(*command) });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,18 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         }
     }
 
+    pub fn end_layout<'commands>(&mut self) -> Vec<RenderCommand<'commands, ImageElementData, CustomElementData>> {
+        let array = unsafe { Clay_EndLayout() };
+        self.dropped = true;
+        let slice = unsafe { core::slice::from_raw_parts(array.internalArray, array.length as _) };
+        let mut commands = Vec::<RenderCommand<'commands, ImageElementData, CustomElementData>>::new();
+        for command in slice.iter(){    
+            commands.push(unsafe { RenderCommand::from_clay_render_command(*command) });
+        }
+
+        commands
+    }
+
     pub fn end(
         &mut self,
     ) -> impl Iterator<Item = RenderCommand<'render, ImageElementData, CustomElementData>> {


### PR DESCRIPTION
`collect()` collects the render command iterator into a vec and provides a seperate lifetime for the function. This is a helper function that allows an easier passing of the rendercommands to other functions.