### PR TITLE
feat: forward scroll_container_data and bounding_box methods in clay scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,16 +284,10 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     }
     
     pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
-        unsafe {
-            Clay_SetCurrentContext(self.clay.context);
-            let scroll_container_data = Clay_GetScrollContainerData(id.id);
-
-            if scroll_container_data.found {
-                Some(scroll_container_data)
-            } else {
-                None
-            }
-        }
+        self.clay.scroll_container_data(id)
+    }
+    pub fn bounding_box(&self, id: Id) -> Option<BoundingBox> {
+        self.clay.bounding_box(id)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     
     pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
         unsafe {
-            Clay_SetCurrentContext(self.context);
+            Clay_SetCurrentContext(self.clay.context);
             let scroll_container_data = Clay_GetScrollContainerData(id.id);
 
             if scroll_container_data.found {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,19 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     pub fn pointer_over(&self, cfg: Id) -> bool {
         unsafe { Clay_PointerOver(cfg.id) }
     }
+    
+    pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
+        unsafe {
+            Clay_SetCurrentContext(self.context);
+            let scroll_container_data = Clay_GetScrollContainerData(id.id);
+
+            if scroll_container_data.found {
+                Some(scroll_container_data)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 impl<ImageElementData, CustomElementData> Drop
@@ -472,18 +485,6 @@ impl Clay {
         }
     }
 
-    pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
-        unsafe {
-            Clay_SetCurrentContext(self.context);
-            let scroll_container_data = Clay_GetScrollContainerData(id.id);
-
-            if scroll_container_data.found {
-                Some(scroll_container_data)
-            } else {
-                None
-            }
-        }
-    }
 
     /// Returns if the current element you are creating is hovered
     pub fn hovered(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,6 +502,18 @@ impl Clay {
             None
         }
     }
+    pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
+        unsafe {
+            Clay_SetCurrentContext(self.context);
+            let scroll_container_data = Clay_GetScrollContainerData(id.id);
+
+            if scroll_container_data.found {
+                Some(scroll_container_data)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
     pub fn pointer_over(&self, cfg: Id) -> bool {
         unsafe { Clay_PointerOver(cfg.id) }
     }
-    
+
     pub fn scroll_container_data(&self, id: Id) -> Option<Clay_ScrollContainerData> {
         self.clay.scroll_container_data(id)
     }
@@ -478,7 +478,6 @@ impl Clay {
             Clay_UpdateScrollContainers(drag_scrolling_enabled, scroll_delta.into(), delta_time);
         }
     }
-
 
     /// Returns if the current element you are creating is hovered
     pub fn hovered(&self) -> bool {


### PR DESCRIPTION
You can't use the Clay struct when you're inside a clay scope so you couldn't use these functions so this basically adds these 2 methods on ClayLayoutScope which are just proxies to the original methods from the clay struct 