### PR TITLE
Fix warnings in code and examples

### DIFF
--- a/examples/basic_rectangle.rs
+++ b/examples/basic_rectangle.rs
@@ -10,7 +10,7 @@ fn main() {
 
     // Adds a red rectangle with a corner radius of 5.
     // The Layout makes the rectangle have a width and height of 50.
-    clay.with(&Declaration::new()
+    clay.with(Declaration::new()
         .id(clay.id("red_rectangle"))
         .layout()
             .width(fixed!(50.))

--- a/examples/raylib_renderer.rs
+++ b/examples/raylib_renderer.rs
@@ -22,14 +22,14 @@ pub fn main() {
 
         #[rustfmt::skip]
         clay.with(
-            &Declaration::new()
+            Declaration::new()
                 .layout()
                     .width(grow!())
                     .height(grow!())
                 .end(),
             |c| {
                 c.with(
-                    &Declaration::new()
+                    Declaration::new()
                         .layout()
                             .width(grow!())
                             .height(grow!())
@@ -42,7 +42,7 @@ pub fn main() {
                 );
 
                 c.with(
-                    &Declaration::new()
+                    Declaration::new()
                         .layout()
                             .width(grow!())
                             .height(grow!())

--- a/examples/wgpu/graphics_context.rs
+++ b/examples/wgpu/graphics_context.rs
@@ -51,8 +51,7 @@ impl<'a> GraphicsContext<'a> {
             .formats
             .iter()
             .copied()
-            .filter(|f| f.is_srgb())
-            .next()
+            .find(|f| f.is_srgb())
             .unwrap_or(surface_capabilities.formats[0]);
 
         let config = wgpu::SurfaceConfiguration {

--- a/examples/wgpu/main.rs
+++ b/examples/wgpu/main.rs
@@ -99,13 +99,13 @@ impl<'a> ApplicationHandler for App<'a> {
                 self.ctx
                     .as_mut()
                     .unwrap()
-                    .render(|mut render_pass, device, queue, config| {
+                    .render(|render_pass, device, queue, config| {
                         ui_renderer.render_clay(
                             render_commands,
-                            &mut render_pass,
-                            &device,
-                            &queue,
-                            &config,
+                            render_pass,
+                            device,
+                            queue,
+                            config,
                         );
                     })
                     .unwrap();
@@ -116,12 +116,11 @@ impl<'a> ApplicationHandler for App<'a> {
                 device_id: _,
                 state,
                 button,
-            } => match button {
-                winit::event::MouseButton::Left => {
+            } => {
+                if button == winit::event::MouseButton::Left {
                     self.clay_user_data.mouse_down_rising_edge = state.is_pressed();
                 }
-                _ => {}
-            },
+            }
             WindowEvent::MouseWheel {
                 device_id: _,
                 delta,

--- a/examples/wgpu/ui_layout.rs
+++ b/examples/wgpu/ui_layout.rs
@@ -45,7 +45,7 @@ fn render_header_button<'a, ImageElementData: 'a, CustomElementData: 'a>(
     text: &str,
 ) {
     clay.with(
-        &Declaration::new()
+        Declaration::new()
             .layout()
             .padding(Padding::new(16, 16, 8, 8))
             .end()
@@ -64,7 +64,7 @@ fn render_dropdown_menu_item<'a, ImageElementData: 'a, CustomElementData: 'a>(
     text: &str,
 ) {
     clay.with(
-        &Declaration::new().layout().padding(Padding::all(16)).end(),
+        Declaration::new().layout().padding(Padding::all(16)).end(),
         |clay| {
             clay.text(text, TextConfig::new().font_size(16).color(WHITE).end());
         },
@@ -110,7 +110,7 @@ pub fn create_layout<'render>(
     let mut clay = clay.begin::<(), ()>();
 
     clay.with(
-        &Declaration::new()
+        Declaration::new()
             .layout()
             .width(grow!())
             .height(grow!())
@@ -124,7 +124,7 @@ pub fn create_layout<'render>(
             .background_color(Color::rgb(43.0, 41.0, 51.0)),
         |clay| {
             clay.with(
-                &Declaration::new()
+                Declaration::new()
                     .content_background_config()
                     .id(clay.id("header_bar"))
                     .layout()
@@ -141,7 +141,7 @@ pub fn create_layout<'render>(
                     .end(),
                 |clay| {
                     clay.with(
-                        &Declaration::new()
+                        Declaration::new()
                             .id(clay.id("file_button"))
                             .layout()
                             .padding(Padding {
@@ -163,7 +163,7 @@ pub fn create_layout<'render>(
 
                             if file_menu_visible {
                                 clay.with(
-                                    &Declaration::new()
+                                    Declaration::new()
                                         .id(clay.id("file_menu"))
                                         .floating()
                                         .attach_to(FloatingAttachToElement::Parent)
@@ -173,7 +173,7 @@ pub fn create_layout<'render>(
                                         .end(),
                                     |clay| {
                                         clay.with(
-                                            &Declaration::new()
+                                            Declaration::new()
                                                 .layout()
                                                 .direction(TopToBottom)
                                                 .width(fixed!(200.0))
@@ -195,7 +195,7 @@ pub fn create_layout<'render>(
                     );
 
                     render_header_button(clay, "Edit");
-                    clay.with(&Declaration::new().layout().width(grow!()).end(), |_| {});
+                    clay.with(Declaration::new().layout().width(grow!()).end(), |_| {});
                     render_header_button(clay, "Upload");
                     render_header_button(clay, "Media");
                     render_header_button(clay, "Support");
@@ -203,7 +203,7 @@ pub fn create_layout<'render>(
             );
 
             clay.with(
-                &Declaration::new()
+                Declaration::new()
                     .layout_expand()
                     .id(clay.id("lower_content"))
                     .layout()
@@ -211,7 +211,7 @@ pub fn create_layout<'render>(
                     .end(),
                 |clay| {
                     clay.with(
-                        &Declaration::new()
+                        Declaration::new()
                             .content_background_config()
                             .id(clay.id("sidebar"))
                             .layout()

--- a/examples/wgpu/ui_renderer.rs
+++ b/examples/wgpu/ui_renderer.rs
@@ -42,7 +42,7 @@ pub struct UIBorderThickness {
     pub right: f32,
 }
 
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Copy, Clone, Debug, Default, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UIPosition {
     pub x: f32,
@@ -52,17 +52,11 @@ pub struct UIPosition {
 
 impl UIPosition {
     pub fn new() -> Self {
-        Self {
-            x: 0.0,
-            y: 0.0,
-            z: 0.0,
-        }
+        Default::default()
     }
 
-    pub fn rotate(&mut self, mut degrees: f32) {
-        degrees = -degrees;
-
-        degrees = degrees * (std::f32::consts::PI / 180.0);
+    pub fn rotate(&mut self, degrees: f32) {
+        let degrees = -degrees.to_radians();
 
         let (sn, cs) = degrees.sin_cos();
 
@@ -233,16 +227,16 @@ impl UIState {
 
         let mut ui_pipeline_builder = UIPipeline::new(pixel_format);
         ui_pipeline_builder.add_buffer_layout(UIVertex::get_layout());
-        let render_pipeline = ui_pipeline_builder.build_pipeline(&device);
+        let render_pipeline = ui_pipeline_builder.build_pipeline(device);
 
         let mut font_system = FontSystem::new();
         let swash_cache = SwashCache::new();
-        let cache = Cache::new(&device);
-        let viewport = Viewport::new(&device, &cache);
-        let mut atlas = TextAtlas::new(&device, &queue, &cache, pixel_format);
+        let cache = Cache::new(device);
+        let viewport = Viewport::new(device, &cache);
+        let mut atlas = TextAtlas::new(device, queue, &cache, pixel_format);
         let text_renderer = TextRenderer::new(
             &mut atlas,
-            &device,
+            device,
             MultisampleState::default(),
             Some(wgpu::DepthStencilState {
                 format: wgpu::TextureFormat::Depth32Float,
@@ -277,7 +271,7 @@ impl UIState {
         queue.write_buffer(
             &self.buffer,
             0,
-            bytemuck::cast_slice(&self.vertices.get(0..self.number_of_vertices).unwrap()),
+            bytemuck::cast_slice(self.vertices.get(0..self.number_of_vertices).unwrap()),
         );
 
         render_pass.set_vertex_buffer(0, self.buffer.slice(..));
@@ -296,7 +290,7 @@ impl UIState {
         self.atlas.trim();
 
         self.viewport.update(
-            &queue,
+            queue,
             Resolution {
                 width: surface_config.width,
                 height: surface_config.height,
@@ -336,8 +330,8 @@ impl UIState {
                 queue,
                 &mut self.font_system,
                 &mut self.atlas,
-                &mut self.viewport,
-                areas.into_iter(),
+                &self.viewport,
+                areas,
                 &mut self.swash_cache,
                 |metadata| (metadata as f32) / 10000.0,
             )
@@ -388,48 +382,42 @@ impl UIState {
     }
 
     pub fn triangle(&mut self, positions: &[UIPosition; 3], color: UIColor) {
-        match self
+        if let Some(vertices) = self
             .vertices
             .get_mut(self.number_of_vertices..self.number_of_vertices + 3)
         {
-            None => return,
-            Some(vertices) => {
-                for (vertex, position) in vertices.iter_mut().zip(positions.iter()) {
-                    vertex.position = *position;
-                    vertex.color = color;
-                    self.number_of_vertices += 1;
-                }
+            for (vertex, position) in vertices.iter_mut().zip(positions.iter()) {
+                vertex.position = *position;
+                vertex.color = color;
+                self.number_of_vertices += 1;
             }
         }
     }
 
     pub fn quad(&mut self, positions: &[UIPosition; 4], color: UIColor) {
-        match self
+        if let Some(vertices) = self
             .vertices
             .get_mut(self.number_of_vertices..self.number_of_vertices + 6)
         {
-            None => return,
-            Some(vertices) => {
-                vertices.get_mut(0).unwrap().position = positions[0];
-                vertices.get_mut(0).unwrap().color = color;
+            vertices.get_mut(0).unwrap().position = positions[0];
+            vertices.get_mut(0).unwrap().color = color;
 
-                vertices.get_mut(1).unwrap().position = positions[1];
-                vertices.get_mut(1).unwrap().color = color;
+            vertices.get_mut(1).unwrap().position = positions[1];
+            vertices.get_mut(1).unwrap().color = color;
 
-                vertices.get_mut(2).unwrap().position = positions[2];
-                vertices.get_mut(2).unwrap().color = color;
+            vertices.get_mut(2).unwrap().position = positions[2];
+            vertices.get_mut(2).unwrap().color = color;
 
-                vertices.get_mut(3).unwrap().position = positions[0];
-                vertices.get_mut(3).unwrap().color = color;
+            vertices.get_mut(3).unwrap().position = positions[0];
+            vertices.get_mut(3).unwrap().color = color;
 
-                vertices.get_mut(4).unwrap().position = positions[2];
-                vertices.get_mut(4).unwrap().color = color;
+            vertices.get_mut(4).unwrap().position = positions[2];
+            vertices.get_mut(4).unwrap().color = color;
 
-                vertices.get_mut(5).unwrap().position = positions[3];
-                vertices.get_mut(5).unwrap().color = color;
+            vertices.get_mut(5).unwrap().position = positions[3];
+            vertices.get_mut(5).unwrap().color = color;
 
-                self.number_of_vertices += 6;
-            }
+            self.number_of_vertices += 6;
         }
     }
 
@@ -769,12 +757,12 @@ impl UIState {
                         UIPosition {
                             x: command.bounding_box.x,
                             y: command.bounding_box.y,
-                            z: depth as f32,
+                            z: depth,
                         },
                         UIPosition {
                             x: command.bounding_box.width,
                             y: command.bounding_box.height,
-                            z: depth as f32,
+                            z: depth,
                         },
                         UIColor {
                             r: r.color.r / 255.0,
@@ -794,12 +782,12 @@ impl UIState {
                         UIPosition {
                             x: command.bounding_box.x,
                             y: command.bounding_box.y,
-                            z: depth as f32,
+                            z: depth,
                         },
                         UIPosition {
                             x: command.bounding_box.width,
                             y: command.bounding_box.height,
-                            z: depth as f32,
+                            z: depth,
                         },
                         UIBorderThickness {
                             top: (b.width.top as f32),
@@ -831,10 +819,10 @@ impl UIState {
                         UIPosition {
                             x: command.bounding_box.x,
                             y: command.bounding_box.y,
-                            z: depth as f32,
+                            z: depth,
                         },
                         match scissor_active {
-                            true => Some((scissor_position.clone(), scissor_bounds.clone())),
+                            true => Some((scissor_position, scissor_bounds)),
                             false => None,
                         },
                         Color::rgb(text.color.r as u8, text.color.g as u8, text.color.b as u8),
@@ -859,7 +847,7 @@ impl UIState {
         if self.number_of_vertices > 0 {
             self.render(render_pass, queue);
         }
-        if self.lines.len() > 0 {
+        if !self.lines.is_empty() {
             self.render_text(device, queue, render_pass, surface_config);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,7 +604,7 @@ mod tests {
 
         let mut clay = clay.begin::<(), ()>();
 
-        clay.with(&Declaration::new()
+        clay.with(Declaration::new()
             .id(clay.id("parent_rect"))
             .layout()
                 .width(Sizing::Fixed(100.0))
@@ -613,7 +613,7 @@ mod tests {
                 .end()
             .background_color(Color::rgb(255., 255., 255.)), |clay|
         {
-            clay.with(&Declaration::new()
+            clay.with(Declaration::new()
                 .layout()
                     .width(Sizing::Fixed(100.0))
                     .height(Sizing::Fixed(100.0))
@@ -621,7 +621,7 @@ mod tests {
                     .end()
                 .background_color(Color::rgb(255., 255., 255.)), |clay|
             {
-                clay.with(&Declaration::new()
+                clay.with(Declaration::new()
                     .id(clay.id("rect_under_rect"))
                     .layout()
                         .width(Sizing::Fixed(100.0))
@@ -639,7 +639,7 @@ mod tests {
             });
         });
 
-        clay.with(&Declaration::new()
+        clay.with(Declaration::new()
             .id(clay.id_index("border_container", 1))
             .layout()
                 .padding(Padding::all(16))
@@ -650,7 +650,7 @@ mod tests {
                 .end()
             .corner_radius().all(10.0).end(), |clay|
         {
-            clay.with(&Declaration::new()
+            clay.with(Declaration::new()
                 .id(clay.id("rect_under_border"))
                 .layout()
                     .width(Sizing::Fixed(50.0))
@@ -681,7 +681,7 @@ mod tests {
 
         let mut clay = clay.begin::<(), ()>();
 
-        clay.with(&Declaration::new()
+        clay.with(Declaration::new()
             .id(clay.id("parent_rect"))
             .layout()
                 .width(Sizing::Fixed(100.0))

--- a/src/renderers/raylib.rs
+++ b/src/renderers/raylib.rs
@@ -153,8 +153,8 @@ pub fn clay_raylib_render<'rl, 'a, CustomElementData: 'a>(
 
                 if border.corner_radii.top_left > 0. {
                     let vec = Vector2::new(
-                        (command.bounding_box.x + border.corner_radii.top_left) as f32,
-                        (command.bounding_box.y + border.corner_radii.top_left) as f32,
+                        command.bounding_box.x + border.corner_radii.top_left,
+                        command.bounding_box.y + border.corner_radii.top_left,
                     );
 
                     d.draw_ring(
@@ -170,9 +170,9 @@ pub fn clay_raylib_render<'rl, 'a, CustomElementData: 'a>(
 
                 if border.corner_radii.top_right > 0. {
                     let vec = Vector2::new(
-                        (command.bounding_box.x + command.bounding_box.width
-                            - border.corner_radii.top_right) as f32,
-                        (command.bounding_box.y + border.corner_radii.top_right) as f32,
+                        command.bounding_box.x + command.bounding_box.width
+                            - border.corner_radii.top_right,
+                        command.bounding_box.y + border.corner_radii.top_right,
                     );
 
                     d.draw_ring(
@@ -188,9 +188,9 @@ pub fn clay_raylib_render<'rl, 'a, CustomElementData: 'a>(
 
                 if border.corner_radii.bottom_left > 0. {
                     let vec = Vector2::new(
-                        (command.bounding_box.x + border.corner_radii.bottom_left) as f32,
-                        (command.bounding_box.y + command.bounding_box.height
-                            - border.corner_radii.bottom_left) as f32,
+                        command.bounding_box.x + border.corner_radii.bottom_left,
+                        command.bounding_box.y + command.bounding_box.height
+                            - border.corner_radii.bottom_left,
                     );
 
                     d.draw_ring(
@@ -206,10 +206,10 @@ pub fn clay_raylib_render<'rl, 'a, CustomElementData: 'a>(
 
                 if border.corner_radii.bottom_right > 0. {
                     let vec = Vector2::new(
-                        (command.bounding_box.x + command.bounding_box.width
-                            - border.corner_radii.bottom_right) as f32,
-                        (command.bounding_box.y + command.bounding_box.height
-                            - border.corner_radii.bottom_right) as f32,
+                        command.bounding_box.x + command.bounding_box.width
+                            - border.corner_radii.bottom_right,
+                        command.bounding_box.y + command.bounding_box.height
+                            - border.corner_radii.bottom_right,
                     );
 
                     d.draw_ring(


### PR DESCRIPTION
One warning about a function with too many arguments was left, since I didn't see any easy way to fix it, and didn't want to do any big refactoring.