### PR TITLE
fix string use-after-free (#75)

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -8,24 +8,24 @@ pub struct Id {
 impl Id {
     /// Creates a clay id using the `label`
     #[inline]
-    pub(crate) fn new(label: &str) -> Id {
+    pub(crate) fn new(label: &'static str) -> Id {
         Self::new_index(label, 0)
     }
 
     /// Creates a clay id using the `label` and the `index`
     #[inline]
-    pub(crate) fn new_index(label: &str, index: u32) -> Id {
+    pub(crate) fn new_index(label: &'static str, index: u32) -> Id {
         Self::new_index_internal(label, index)
     }
 
     #[inline]
-    pub(crate) fn new_index_internal(label: &str, index: u32) -> Id {
+    pub(crate) fn new_index_internal(label: &'static str, index: u32) -> Id {
         let id = unsafe { Clay__HashString(label.into(), index, 0) };
         Id { id }
     }
 
     #[inline]
-    pub(crate) fn new_index_local(label: &str, index: u32) -> Id {
+    pub(crate) fn new_index_local(label: &'static str, index: u32) -> Id {
         let id = unsafe { Clay__HashString(label.into(), index, Clay__GetParentElementId()) };
         Id { id }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ impl Clay {
     ///
     /// This ID is global and must be unique across the entire scope.
     #[inline]
-    pub fn id(&self, label: &str) -> id::Id {
+    pub fn id(&self, label: &'static str) -> id::Id {
         id::Id::new(label)
     }
 
@@ -382,7 +382,7 @@ impl Clay {
     ///
     /// This is useful when multiple elements share the same label but need distinct IDs.
     #[inline]
-    pub fn id_index(&self, label: &str, index: u32) -> id::Id {
+    pub fn id_index(&self, label: &'static str, index: u32) -> id::Id {
         id::Id::new_index(label, index)
     }
 
@@ -390,7 +390,7 @@ impl Clay {
     ///
     /// The ID is unique within a specific local scope but not globally.
     #[inline]
-    pub fn id_local(&self, label: &str) -> id::Id {
+    pub fn id_local(&self, label: &'static str) -> id::Id {
         id::Id::new_index_local(label, 0)
     }
 
@@ -398,7 +398,7 @@ impl Clay {
     ///
     /// This is useful for differentiating elements within a local scope while keeping their labels consistent.
     #[inline]
-    pub fn id_index_local(&self, label: &str, index: u32) -> id::Id {
+    pub fn id_index_local(&self, label: &'static str, index: u32) -> id::Id {
         id::Id::new_index_local(label, index)
     }
 
@@ -591,7 +591,7 @@ impl Drop for Clay {
 impl From<&str> for Clay_String {
     fn from(value: &str) -> Self {
         Self {
-            isStaticallyAllocated: false,
+            isStaticallyAllocated: true,
             length: value.len() as _,
             chars: value.as_ptr() as _,
         }


### PR DESCRIPTION
Addressing #75 
- Use `owned_strings` to keep strings alive
- Copy unknown-lifetime strings
- Introduce text_literal and text_string methods for differentiation