### PR TITLE
feat:  add on_hover, pointer_over_ids, is_debug_mode, set_culling

### DIFF
--- a/src/bindings/bindings.rs
+++ b/src/bindings/bindings.rs
@@ -1030,10 +1030,10 @@ unsafe extern "C" {
             unsafe extern "C" fn(
                 elementId: Clay_ElementId,
                 pointerData: Clay_PointerData,
-                userData: isize,
+                userData: *mut ::core::ffi::c_void,
             ),
         >,
-        userData: isize,
+        userData: *mut ::core::ffi::c_void,
     );
 }
 unsafe extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,18 @@ impl Clay {
         }
     }
 
+    /// Returns if debug mode is enabled
+    pub fn is_debug_mode(&self) -> bool {
+        unsafe { Clay_IsDebugModeEnabled() }
+    }
+
+    /// Enables or disables culling
+    pub fn set_culling(&self, enable: bool) {
+        unsafe {
+            Clay_SetCullingEnabled(enable);
+        }
+    }
+
     /// Sets the dimensions of the global layout, use if, for example the window size you render to
     /// changed
     pub fn set_layout_dimensions(&self, dimensions: Dimensions) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,16 @@ impl Clay {
         unsafe { Clay_PointerOver(cfg.id) }
     }
 
+    #[cfg(feature = "std")]
+    /// Z-sorted list of element IDs that the cursor is currently over
+    pub fn pointer_over_ids(&self) -> Vec<Id> {
+        unsafe {
+            let array = Clay_GetPointerOverIds();
+            let slice = core::slice::from_raw_parts(array.internalArray, array.length as _);
+            slice.iter().map(|&id| Id { id }).collect()
+        }
+    }
+
     #[cfg(not(feature = "std"))]
     pub unsafe fn new_with_memory(dimensions: Dimensions, memory: *mut core::ffi::c_void) -> Self {
         let memory_size = Self::required_memory_size();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         unsafe { Clay_Hovered() }
     }
 
+    #[cfg(feature = "std")]
     pub fn on_hover<F, T>(&self, callback: F, user_data: T)
     where
         F: Fn(Id, Clay_PointerData, &mut T) + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
 
     pub fn on_hover<F, T>(&self, callback: F, user_data: T)
     where
-        F: Fn(Id, Clay_PointerData, &mut T) + 'static
+        F: Fn(Id, Clay_PointerData, &mut T) + 'static,
     {
         let boxed = Box::new((callback, user_data));
         let user_data_ptr = Box::into_raw(boxed) as *mut core::ffi::c_void;
@@ -266,8 +266,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
             element_id: Clay_ElementId,
             pointer_data: Clay_PointerData,
             user_data: *mut core::ffi::c_void,
-        )
-        where
+        ) where
             F: Fn(Id, Clay_PointerData, &mut T) + 'static,
         {
             let (callback, data) = &mut *(user_data as *mut (F, T));
@@ -276,10 +275,7 @@ impl<'render, 'clay: 'render, ImageElementData: 'render, CustomElementData: 'ren
         }
 
         unsafe {
-            Clay_OnHover(
-                Some(trampoline::<F, T>),
-                user_data_ptr,
-            );
+            Clay_OnHover(Some(trampoline::<F, T>), user_data_ptr);
         }
     }
 


### PR DESCRIPTION
- `on_hover` method that allows users to register Rust callbacks for hover events
- `pointer_over_ids` method  to retrieve a Z-sorted list of all element IDs currently under the cursor
- `is_debug_mode` and `set_culling` methods

I'm making a lot of PRs, you can check my main branch on how these would be merged.