### PR TITLE
chore: Update README to help users with libclang

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ To build bindings you need to use the `generate_bindings` script. \
 It needs `bindgen` installed as a CLI, you can install it with `cargo install bindgen`. \
 Calling it will use the `clay.h` in the project root, or any `clay.h` file provided with `CLAY_HEADER_PATH`. \
 Using the clay header it will generate `src/bindings/bindings.rs` and `src/bindings/bindings_debug.rs`.
+
+## Dependencies
+For Linux, this binding requires `libclang.so` to be installed on the systemto successfully compile. This primarily affects the raylib renderer.
+
+This can be provided by a `clang` package on most distros.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ Calling it will use the `clay.h` in the project root, or any `clay.h` file provi
 Using the clay header it will generate `src/bindings/bindings.rs` and `src/bindings/bindings_debug.rs`.
 
 ## Dependencies
-For Linux, this binding requires `libclang.so` to be installed on the systemto successfully compile. This primarily affects the raylib renderer.
+For Linux, this binding requires `libclang.so` to be installed on the system to successfully compile. This primarily affects the raylib renderer.
 
 This can be provided by a `clang` package on most distros.


### PR DESCRIPTION
I came across the following error, this PR adds a small notice at the bottom of the README to inform users.
I can also open an issue and start looking into fixes if asking the user to add a dependency to their system is undesired.

Error:
```
 Compiling raylib-sys v5.5.1
error: failed to run custom build command for `raylib-sys v5.5.1`

Caused by:
  process didn't exit successfully: `/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-a69aa78d3792f03a/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=./binding/binding.h
  CMAKE_TOOLCHAIN_FILE_x86_64-unknown-linux-gnu = None
  CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_x86_64-unknown-linux-gnu = None
  CMAKE_GENERATOR_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_x86_64-unknown-linux-gnu = None
  CMAKE_PREFIX_PATH_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_x86_64-unknown-linux-gnu = None
  CMAKE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE = None
  CMAKE = None
  -- Testing if -Werror=pointer-arith can be used -- compiles
  -- Testing if -Werror=implicit-function-declaration can be used -- compiles
  -- Testing if -fno-strict-aliasing can be used -- compiles
  -- Using raylib's GLFW
  -- Including X11 support
  -- Audio Backend: miniaudio
  -- Building raylib static library
  -- Generated build type: Debug
  -- Compiling with the flags:
  --   PLATFORM=PLATFORM_DESKTOP
  --   GRAPHICS=GRAPHICS_API_OPENGL_33
  -- Configuring done (0.1s)
  -- Generating done (0.0s)
  -- Build files have been written to: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/build
  [ 74%] Built target glfw
  [100%] Built target raylib
  Install the project...
  -- Install configuration: "Debug"
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/lib/libraylib.a
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/include/raylib.h
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/include/rlgl.h
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/include/raymath.h
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/lib/pkgconfig/raylib.pc
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/lib/cmake/raylib/raylib-config-version.cmake
  -- Up-to-date: /home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/lib/cmake/raylib/raylib-config.cmake
  cargo:root=/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out
  cargo:rustc-link-search=native=/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/lib

  --- stderr
  running: cd "/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/home/Chaseis4344/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/raylib
-sys-5.5.1/./raylib" "-B" "/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/build" "-DCMAKE_BUILD_TYPE=Debug" "-DBUILD_EXAMPLES=OFF" "-DCMAKE_BUILD_TYPE=Debug" "-DSUPPORT_BUSY_WAIT_LOOP=OFF" "
-DSUPPORT_FILEFORMAT_JPG=ON" "-DUSE_WAYLAND=OFF" "-DOPENGL_VERSION=OFF" "-DSUPPORT_SCREEN_CAPTURE=ON" "-DSUPPORT_GIF_RECORDING=ON" "-DPLATFORM=Desktop" "-DCMAKE_INSTALL_PREFIX=/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build
/raylib-sys-2d44bac29fd0a034/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_CXX_COMPILER=/usr/b
in/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 -w" "-DCMAKE_ASM_COMPILER=/usr/bin/cc"
  running: cd "/home/Chaseis4344/Projects/Rust/clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/build" && LC_ALL="C" MAKEFLAGS="-j --jobserver-fds=8,9 --jobserver-auth=8,9" "cmake" "--build" "/home/Chaseis4344/Projects/Rust/
clay_app/target/debug/build/raylib-sys-2d44bac29fd0a034/out/build" "--target" "install" "--config" "Debug"

  thread 'main' (30862) panicked at /home/Chaseis4344/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.70.1/lib.rs:622:27:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be
 found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
